### PR TITLE
Fixes two integer underflows when dumping the EBNF grammars for PraTTaIL

### DIFF
--- a/prattail/src/ebnf.rs
+++ b/prattail/src/ebnf.rs
@@ -201,7 +201,7 @@ fn write_lexical_tokens(buf: &mut String, categories: &[CategoryInfo]) {
             "<integer> = /[0-9]+/{:>pad$}(* {} *) ;",
             "",
             integer_type,
-            pad = 22 - "<integer> = /[0-9]+/".len() + 22
+            pad = 44_usize.saturating_sub("<integer> = /[0-9]+/".len())
         )
         .unwrap();
     }
@@ -211,7 +211,7 @@ fn write_lexical_tokens(buf: &mut String, categories: &[CategoryInfo]) {
             "<float>   = /[0-9]+\\.[0-9]+/{:>pad$}(* {} *) ;",
             "",
             float_type,
-            pad = 22 - "<float>   = /[0-9]+\\.[0-9]+/".len() + 22
+            pad = 44_usize.saturating_sub("<float>   = /[0-9]+\\.[0-9]+/".len())
         )
         .unwrap();
     }


### PR DESCRIPTION
This PR addresses a regression that was introduced into the EBNF writing logic of PraTTaIL that resulted in two integer underflows when the `PRATTAIL_DUMP_EBNF` environment variable was set to `1` or a directory path.