### PR TITLE
  feat(release): nightly release workflow + workspace metadata unification

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [ main ]
+    branches: [ main, dev ]
   pull_request:
-    branches: [ main ]
+    branches: [ main, dev ]
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,127 @@
+name: Release
+
+on:
+  schedule:
+    # Nightly at 06:00 UTC. No-op if workspace version has not changed.
+    - cron: '0 6 * * *'
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  release:
+    name: Tag and publish GitHub Release
+    runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/main'
+    outputs:
+      released: ${{ steps.gate.outputs.released }}
+      version: ${{ steps.gate.outputs.version }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Read workspace version
+        id: version
+        run: |
+          v=$(awk '
+            /^\[workspace\.package\]/ { in_block=1; next }
+            in_block && /^\[/         { in_block=0 }
+            in_block && /^version[[:space:]]*=/ {
+                match($0, /"[^"]+"/)
+                if (RSTART > 0) { print substr($0, RSTART+1, RLENGTH-2); exit }
+            }
+          ' Cargo.toml)
+          if [ -z "$v" ]; then
+            echo "::error::Could not read workspace.package.version from Cargo.toml"
+            exit 1
+          fi
+          echo "version=$v" >> "$GITHUB_OUTPUT"
+          echo "Workspace version: $v"
+
+      - name: Check if tag already exists
+        id: gate
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          tag="v$VERSION"
+          if git rev-parse "refs/tags/$tag" >/dev/null 2>&1; then
+            echo "Tag $tag already exists; no release needed."
+            echo "released=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "No tag for $VERSION yet; will cut release."
+            echo "released=true" >> "$GITHUB_OUTPUT"
+            echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Extract release notes from CHANGELOG.md
+        if: steps.gate.outputs.released == 'true'
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          awk -v v="$VERSION" '
+            /^## \[/ {
+              if (section) exit
+              if ($0 ~ "^## \\[" v "\\]") { section=1; next }
+              next
+            }
+            section { print }
+          ' CHANGELOG.md > .release-notes.md
+          if [ ! -s .release-notes.md ]; then
+            echo "::warning::No CHANGELOG section found for [$VERSION]; falling back to placeholder"
+            echo "Release v$VERSION" > .release-notes.md
+          fi
+          echo "--- release notes ---"
+          cat .release-notes.md
+
+      - name: Create git tag
+        if: steps.gate.outputs.released == 'true'
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git tag -a "v$VERSION" -m "Release v$VERSION"
+          git push origin "v$VERSION"
+
+      - name: Create GitHub Release
+        if: steps.gate.outputs.released == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          gh release create "v$VERSION" \
+            --title "v$VERSION" \
+            --notes-file .release-notes.md
+
+  publish-crates:
+    name: Publish to crates.io
+    runs-on: ubuntu-latest
+    needs: release
+    if: needs.release.outputs.released == 'true'
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: refs/tags/v${{ needs.release.outputs.version }}
+
+      - name: Install Rust stable
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Strip nightly-only cargo config for stable build
+        run: |
+          sed -i.bak '/codegen-backend/d' Cargo.toml
+          if [ -f .cargo/config.toml ]; then
+            sed -i.bak '/codegen-backend/d' .cargo/config.toml
+          fi
+
+      - name: Publish publishable crates in dependency order
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+        run: bash AItools/scripts/publish-crates.sh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,6 +43,10 @@ jobs:
             echo "::error::Could not read workspace.package.version from Cargo.toml"
             exit 1
           fi
+          if [[ ! "$v" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?(\+[0-9A-Za-z.-]+)?$ ]]; then
+            echo "::error::Parsed version '$v' is not valid SemVer"
+            exit 1
+          fi
           echo "version=$v" >> "$GITHUB_OUTPUT"
           echo "Workspace version: $v"
 

--- a/AItools/scripts/generate-changelog.sh
+++ b/AItools/scripts/generate-changelog.sh
@@ -1,0 +1,237 @@
+#!/usr/bin/env bash
+#
+# generate-changelog.sh - Generate CHANGELOG.md entries from git history.
+#
+# Parses conventional commit prefixes and groups into Keep a Changelog categories.
+# Version comes from `workspace.package.version` in the root Cargo.toml (SemVer).
+#
+# Intended workflow: run locally on `dev` before opening a release PR. Bump the
+# workspace version in Cargo.toml first, then run this to populate the matching
+# changelog section. The release workflow on `main` reads the resulting section
+# to build the GitHub Release body.
+#
+# Usage:
+#   generate-changelog.sh                    # Update CHANGELOG.md for current workspace version
+#   generate-changelog.sh --dry-run          # Print what would be generated (no file writes)
+#   generate-changelog.sh --since <commit>   # Override the "previous release" commit
+#   generate-changelog.sh --version X.Y.Z    # Override version (default: read from Cargo.toml)
+#   generate-changelog.sh --verbose          # Show detailed progress
+#   generate-changelog.sh --help / -h        # Usage
+#
+# Options:
+#   --dry-run           Print output without writing files
+#   --since COMMIT      Override the starting commit for the range
+#   --version X.Y.Z     Override the target version
+#   --verbose           Show detailed progress
+#   --help, -h          Show this help message
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+CHANGELOG="$PROJECT_ROOT/CHANGELOG.md"
+CARGO_TOML="$PROJECT_ROOT/Cargo.toml"
+
+DRY_RUN=false
+VERBOSE=false
+SINCE=""
+VERSION_OVERRIDE=""
+
+if [[ -t 1 ]]; then
+    RED='\033[0;31m'
+    GREEN='\033[0;32m'
+    YELLOW='\033[0;33m'
+    BLUE='\033[0;34m'
+    NC='\033[0m'
+else
+    RED='' GREEN='' YELLOW='' BLUE='' NC=''
+fi
+
+log_info()    { echo -e "${BLUE}[INFO]${NC} $1"; }
+log_ok()      { echo -e "${GREEN}[OK]${NC} $1"; }
+log_warn()    { echo -e "${YELLOW}[WARN]${NC} $1" >&2; }
+log_error()   { echo -e "${RED}[ERROR]${NC} $1" >&2; }
+log_verbose() { [[ "$VERBOSE" == "true" ]] && echo -e "  $1" || true; }
+
+usage() {
+    sed -n '/^# Usage:/,/^#$/p' "$0" | sed 's/^# \?//'
+    echo ""
+    sed -n '/^# Options:/,/^[^#]/p' "$0" | sed '/^[^#]/d; s/^# \?//'
+}
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --dry-run)    DRY_RUN=true; shift ;;
+        --since)      SINCE="$2"; shift 2 ;;
+        --version)    VERSION_OVERRIDE="$2"; shift 2 ;;
+        --verbose)    VERBOSE=true; shift ;;
+        --help|-h)    usage; exit 0 ;;
+        *)            log_error "Unknown option: $1"; usage; exit 1 ;;
+    esac
+done
+
+cd "$PROJECT_ROOT"
+
+# Read workspace version from Cargo.toml [workspace.package] block.
+read_workspace_version() {
+    awk '
+        /^\[workspace\.package\]/ { in_block=1; next }
+        in_block && /^\[/         { in_block=0 }
+        in_block && /^version[[:space:]]*=/ {
+            # version = "X.Y.Z"
+            match($0, /"[^"]+"/)
+            if (RSTART > 0) {
+                v = substr($0, RSTART+1, RLENGTH-2)
+                print v
+                exit
+            }
+        }
+    ' "$CARGO_TOML"
+}
+
+if [[ -n "$VERSION_OVERRIDE" ]]; then
+    VERSION="$VERSION_OVERRIDE"
+else
+    VERSION="$(read_workspace_version)"
+fi
+
+if [[ -z "$VERSION" ]]; then
+    log_error "Could not read workspace.package.version from $CARGO_TOML"
+    exit 1
+fi
+
+# Validate SemVer shape (allow pre-release / build metadata suffixes).
+if ! [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+([-+][0-9A-Za-z.-]+)?$ ]]; then
+    log_error "Version '$VERSION' is not valid SemVer"
+    exit 1
+fi
+
+TAG="v$VERSION"
+log_info "Target version: $VERSION (tag: $TAG)"
+
+# Determine commit range.
+if [[ -n "$SINCE" ]]; then
+    RANGE_START="$SINCE"
+    log_info "Using --since override: $RANGE_START"
+elif git describe --tags --abbrev=0 --match 'v*.*.*' HEAD 2>/dev/null 1>&2; then
+    RANGE_START=$(git describe --tags --abbrev=0 --match 'v*.*.*' HEAD)
+    log_info "Using latest SemVer tag: $RANGE_START"
+else
+    RANGE_START=$(git rev-list --max-parents=0 HEAD 2>/dev/null | head -1)
+    log_info "No SemVer tags found; using root commit: ${RANGE_START:0:8}"
+fi
+
+COMMITS=$(git log --oneline "$RANGE_START"..HEAD 2>/dev/null || true)
+
+if [[ -z "$COMMITS" ]]; then
+    log_warn "No commits found in range ${RANGE_START:0:8}..HEAD"
+    log_info "Nothing to generate"
+    exit 0
+fi
+
+COMMIT_COUNT=$(echo "$COMMITS" | wc -l | tr -d ' ')
+log_info "Found $COMMIT_COUNT commits since ${RANGE_START:0:8}"
+
+# Categorize commits.
+ADDED=""
+CHANGED=""
+FIXED=""
+REMOVED=""
+
+while IFS= read -r line; do
+    msg="${line#* }"
+    log_verbose "Processing: $msg"
+
+    case "$msg" in
+        feat\(*\):*|feat:*)
+            entry="${msg#*: }"
+            ADDED="${ADDED}${ADDED:+$'\n'}- ${entry}"
+            ;;
+        fix\(*\):*|fix:*)
+            entry="${msg#*: }"
+            FIXED="${FIXED}${FIXED:+$'\n'}- ${entry}"
+            ;;
+        docs\(*\):*|docs:*|chore\(*\):*|chore:*|refactor\(*\):*|refactor:*|test\(*\):*|test:*|ci\(*\):*|ci:*|style\(*\):*|style:*|perf\(*\):*|perf:*|build\(*\):*|build:*)
+            entry="${msg#*: }"
+            if echo "$entry" | grep -qi 'remov\|delet'; then
+                REMOVED="${REMOVED}${REMOVED:+$'\n'}- ${entry}"
+            else
+                CHANGED="${CHANGED}${CHANGED:+$'\n'}- ${entry}"
+            fi
+            ;;
+        *)
+            # Non-conventional: tolerate and bucket under Changed (or Removed if keywords match).
+            if echo "$msg" | grep -qi 'remov\|delet'; then
+                REMOVED="${REMOVED}${REMOVED:+$'\n'}- ${msg}"
+            else
+                CHANGED="${CHANGED}${CHANGED:+$'\n'}- ${msg}"
+            fi
+            ;;
+    esac
+done <<< "$COMMITS"
+
+# Build changelog block for the target version.
+TODAY=$(date -u +%Y-%m-%d)
+BLOCK="## [$VERSION] - $TODAY"$'\n'
+
+if [[ -n "$ADDED" ]]; then
+    BLOCK="$BLOCK"$'\n'"### Added"$'\n'"$ADDED"$'\n'
+fi
+if [[ -n "$CHANGED" ]]; then
+    BLOCK="$BLOCK"$'\n'"### Changed"$'\n'"$CHANGED"$'\n'
+fi
+if [[ -n "$FIXED" ]]; then
+    BLOCK="$BLOCK"$'\n'"### Fixed"$'\n'"$FIXED"$'\n'
+fi
+if [[ -n "$REMOVED" ]]; then
+    BLOCK="$BLOCK"$'\n'"### Removed"$'\n'"$REMOVED"$'\n'
+fi
+
+if [[ "$DRY_RUN" == "true" ]]; then
+    echo ""
+    echo "=== CHANGELOG.md entry for [$VERSION] ==="
+    echo "$BLOCK"
+    exit 0
+fi
+
+CHANGELOG_HEADER="# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+"
+
+if [[ -f "$CHANGELOG" ]]; then
+    # Insert the new block after [Unreleased]. If an entry for this version
+    # already exists, replace it (idempotent on re-run during the same release).
+    TMPFILE=$(mktemp)
+    trap "rm -f $TMPFILE" EXIT
+
+    awk -v block="$BLOCK" -v target="## [$VERSION]" '
+        BEGIN { in_old = 0 }
+        # Emit new block right after [Unreleased] header.
+        /^## \[Unreleased\]/ && !inserted {
+            print
+            printf "\n%s\n", block
+            inserted = 1
+            next
+        }
+        # If an old entry for this exact version exists, skip it until next ## heading.
+        {
+            if (index($0, target) == 1) { in_old = 1; next }
+            if (in_old && $0 ~ /^## \[/) { in_old = 0 }
+            if (!in_old) print
+        }
+    ' "$CHANGELOG" > "$TMPFILE"
+
+    mv "$TMPFILE" "$CHANGELOG"
+    trap - EXIT
+else
+    printf '%s\n%s\n' "$CHANGELOG_HEADER" "$BLOCK" > "$CHANGELOG"
+fi
+
+log_ok "Updated CHANGELOG.md [$VERSION] ($COMMIT_COUNT commits since ${RANGE_START:0:8})"

--- a/AItools/scripts/generate-changelog.sh
+++ b/AItools/scripts/generate-changelog.sh
@@ -102,7 +102,7 @@ if [[ -z "$VERSION" ]]; then
 fi
 
 # Validate SemVer shape (allow pre-release / build metadata suffixes).
-if ! [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+([-+][0-9A-Za-z.-]+)?$ ]]; then
+if ! [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?(\+[0-9A-Za-z.-]+)?$ ]]; then
     log_error "Version '$VERSION' is not valid SemVer"
     exit 1
 fi

--- a/AItools/scripts/publish-crates.sh
+++ b/AItools/scripts/publish-crates.sh
@@ -76,7 +76,11 @@ PY
 ) <<<"$metadata"
 }
 
-mapfile -t TO_PUBLISH < <(ordered_members)
+members_output=$(ordered_members) || { echo "::error::Failed to determine publish order"; exit 1; }
+mapfile -t TO_PUBLISH <<< "$members_output"
+if [[ ${#TO_PUBLISH[@]} -eq 1 && -z "${TO_PUBLISH[0]}" ]]; then
+    TO_PUBLISH=()
+fi
 
 if [[ ${#TO_PUBLISH[@]} -eq 0 ]]; then
     echo "[publish-crates] No publishable crates (all members have publish = false). Skipping."
@@ -90,7 +94,7 @@ done
 
 for n in "${TO_PUBLISH[@]}"; do
     echo "[publish-crates] cargo publish -p $n"
-    cargo publish -p "$n" --token "$CARGO_REGISTRY_TOKEN"
+    cargo publish -p "$n"
     # Give the index time to propagate before the next dependent publishes.
     sleep 15
 done

--- a/AItools/scripts/publish-crates.sh
+++ b/AItools/scripts/publish-crates.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+#
+# publish-crates.sh - Publish workspace crates to crates.io in dependency order.
+#
+# Enumerates workspace members via `cargo metadata`, filters out those with
+# `publish = false`, topologically sorts by intra-workspace dependencies, and
+# publishes each with `cargo publish`.
+#
+# Requires CARGO_REGISTRY_TOKEN in the environment.
+#
+# Notes:
+#   - Crates with `publish = false` are skipped (the current default for this
+#     workspace). To publish a crate, remove `publish = false` from its
+#     Cargo.toml AND ensure intra-workspace path deps carry explicit versions
+#     (e.g. `mettail-runtime = { path = "../runtime", version = "0.1.0" }`).
+#   - A short sleep between publishes gives the crates.io index time to pick
+#     up newly published versions before publishing dependents.
+
+set -euo pipefail
+
+if [[ -z "${CARGO_REGISTRY_TOKEN:-}" ]]; then
+    echo "::error::CARGO_REGISTRY_TOKEN not set"
+    exit 1
+fi
+
+# Produce a newline-separated, topologically sorted list of publishable
+# workspace member names. Exits 0 with empty output if none are publishable.
+ordered_members() {
+    local metadata
+    metadata=$(cargo metadata --format-version 1 --no-deps)
+    python3 <(cat <<'PY'
+import json, sys
+from collections import defaultdict, deque
+
+m = json.load(sys.stdin)
+members = {p["name"]: p for p in m["packages"] if p["id"] in m["workspace_members"]}
+
+# Filter out publish = false. Cargo metadata reports `publish: null` when the
+# crate is publishable (to any registry), and `publish: []` when publish=false.
+publishable = {n for n, p in members.items() if p.get("publish") is None}
+
+# Build intra-workspace dependency DAG, only among publishable members.
+deps = defaultdict(set)
+indeg = defaultdict(int)
+for n in publishable:
+    deps[n] = set()
+    indeg[n] = 0
+for n in publishable:
+    for d in members[n].get("dependencies", []):
+        if d.get("kind") in (None, "normal", "build") and d["name"] in publishable:
+            if d["name"] not in deps[n]:
+                deps[n].add(d["name"])
+                indeg[n] += 1
+
+# Kahn's algorithm.
+ready = deque(sorted(n for n, c in indeg.items() if c == 0))
+order = []
+while ready:
+    n = ready.popleft()
+    order.append(n)
+    for other in publishable:
+        if n in deps[other]:
+            deps[other].remove(n)
+            indeg[other] -= 1
+            if indeg[other] == 0:
+                ready.append(other)
+
+if len(order) != len(publishable):
+    missing = set(publishable) - set(order)
+    print(f"ERROR: dependency cycle among {missing}", file=sys.stderr)
+    sys.exit(2)
+
+for n in order:
+    print(n)
+PY
+) <<<"$metadata"
+}
+
+mapfile -t TO_PUBLISH < <(ordered_members)
+
+if [[ ${#TO_PUBLISH[@]} -eq 0 ]]; then
+    echo "[publish-crates] No publishable crates (all members have publish = false). Skipping."
+    exit 0
+fi
+
+echo "[publish-crates] Will publish in order:"
+for n in "${TO_PUBLISH[@]}"; do
+    echo "  - $n"
+done
+
+for n in "${TO_PUBLISH[@]}"; do
+    echo "[publish-crates] cargo publish -p $n"
+    cargo publish -p "$n" --token "$CARGO_REGISTRY_TOKEN"
+    # Give the index time to propagate before the next dependent publishes.
+    sleep 15
+done
+
+echo "[publish-crates] Done."

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,9 +9,14 @@ resolver = "2"
 
 [package]
 name = "mettail"
-version = "0.1.0"
-edition = "2021"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
 default-run = "mettail"
+publish = false
 
 [[bin]]
 name = "mettail"
@@ -31,8 +36,8 @@ version = "0.1.0"
 edition = "2021"
 authors = ["MeTTaIL Contributors"]
 license = "MIT"
-repository = "https://github.com/cb-wells/mettail-rust"
-homepage = "https://github.com/cb-wells/mettail-rust"
+repository = "https://github.com/F1R3FLY-io/mettail-rust"
+homepage = "https://github.com/F1R3FLY-io/mettail-rust"
 
 [workspace.dependencies]
 proc-macro2 = "1.0"

--- a/README.md
+++ b/README.md
@@ -123,6 +123,56 @@ Applied rewrite →
 
 ---
 
+## Development Setup
+
+### Prerequisites
+
+- **Rust nightly** toolchain (for Cranelift codegen backend)
+- **Fast linker** (optional but configured by default in `.cargo/config.toml`):
+
+  **macOS:**
+  ```sh
+  brew install llvm
+  # Apple Silicon:
+  export PATH="/opt/homebrew/opt/llvm/bin:$PATH"
+  # Intel Mac:
+  export PATH="/usr/local/opt/llvm/bin:$PATH"
+  ```
+
+  **Linux:**
+  ```sh
+  # Debian/Ubuntu
+  sudo apt install mold
+  # Arch
+  sudo pacman -S mold
+  # Fedora
+  sudo dnf install mold
+  ```
+
+  If you don't want to install a fast linker, comment out the `linker` and `rustflags` lines for your platform in `.cargo/config.toml`.
+
+### Building and Testing
+
+```sh
+cargo build                              # dev build (Cranelift backend)
+cargo build --release                    # release build (LLVM backend)
+cargo test --all-features --workspace    # full test suite
+cargo run                                # launch the REPL
+```
+
+### Git Hooks
+
+The repository includes pre-commit and pre-push hooks that run formatting, linting, and tests. To enable them:
+
+```sh
+git config core.hooksPath hooks/
+```
+
+**Pre-commit** runs `cargo fmt --check`, `cargo clippy`, and `cargo test`.
+**Pre-push** runs the test suite and verifies a release build compiles. It includes a race guard that skips checks when the remote is already up to date.
+
+---
+
 ## 🙏 Credits
 
 **Core Technologies:**

--- a/ascent_syntax_export/Cargo.toml
+++ b/ascent_syntax_export/Cargo.toml
@@ -1,8 +1,13 @@
 [package]
 name = "ascent_syntax_export"
 version.workspace = true
-edition = "2021"
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
 description = "Non-proc-macro wrapper to export Ascent's parser types for external use"
+publish = false
 
 [dependencies]
 syn = { version = "2.0.57", features = ["derive", "full", "extra-traits", "visit-mut", "parsing"] }

--- a/docs/Backlog.md
+++ b/docs/Backlog.md
@@ -1,0 +1,183 @@
+---
+doc_type: backlog
+version: "1.0"
+last_updated: [DATE]
+---
+
+# Backlog
+
+<!--
+TEMPLATE USAGE INSTRUCTIONS:
+0. Update the frontmatter date when modifying this file
+   (Update version only for significant structural changes to template)
+1. Replace all [PROJECT_NAME] and [PROJECT_SPECIFIC] markers
+2. Add deferred or low-priority items here
+3. Move items to docs/ToDos.md when ready to work on them
+4. Remove these usage instruction comments before committing
+-->
+
+This document captures deferred work, future ideas, and low-priority items that aren't ready for active development.
+
+**Document Structure**
+- Active work: `docs/ToDos.md`
+- User stories: `docs/UserStories.md`
+- Completed work: `docs/CompletedTasks.md`
+- Deferred work: This file (`docs/Backlog.md`)
+
+**For LLM assistance in multi-repo workspace:**
+See [Task Tracking Standard]([RELATIVE_PATH]/top-level-gitlab-profile/docs/common/task-tracking-standard.md)
+
+**For reference (GitLab):**
+[Task Tracking Standard](https://gitlab.com/smart-assets.io/gitlab-profile/-/blob/master/docs/common/task-tracking-standard.md)
+
+---
+
+## Backlog Categories
+
+Items are organized by category and rough priority within each category.
+
+---
+
+### Technical Debt
+
+Items that improve code quality, performance, or maintainability but aren't blocking active development.
+
+---
+
+#### BACKLOG-TD-001: [PROJECT_SPECIFIC: Item Title]
+
+```yaml
+---
+backlog_id: BACKLOG-TD-001
+title: "[PROJECT_SPECIFIC: Item Title]"
+category: technical_debt
+priority: p3
+added_at: [DATE]
+reason_deferred: "[PROJECT_SPECIFIC: Why this isn't active yet]"
+promotion_criteria:
+  - "[PROJECT_SPECIFIC: When should this become active?]"
+---
+```
+
+**Description:** [PROJECT_SPECIFIC: What needs to be done?]
+
+**Benefit:** [PROJECT_SPECIFIC: Why is this valuable?]
+
+---
+
+### Feature Ideas
+
+Future features that have been identified but aren't yet prioritized.
+
+---
+
+#### BACKLOG-FI-001: [PROJECT_SPECIFIC: Feature Idea Title]
+
+```yaml
+---
+backlog_id: BACKLOG-FI-001
+title: "[PROJECT_SPECIFIC: Feature Idea Title]"
+category: feature_idea
+priority: p3
+added_at: [DATE]
+user_story: null         # Link when user story is created
+reason_deferred: "[PROJECT_SPECIFIC: Why this isn't active yet]"
+promotion_criteria:
+  - "[PROJECT_SPECIFIC: When should this become active?]"
+---
+```
+
+**Description:** [PROJECT_SPECIFIC: What is the feature?]
+
+**Value Proposition:** [PROJECT_SPECIFIC: Who benefits and how?]
+
+---
+
+### Research & Exploration
+
+Items that need investigation before they can become actionable tasks.
+
+---
+
+#### BACKLOG-RE-001: [PROJECT_SPECIFIC: Research Topic]
+
+```yaml
+---
+backlog_id: BACKLOG-RE-001
+title: "[PROJECT_SPECIFIC: Research Topic]"
+category: research
+priority: p3
+added_at: [DATE]
+questions:
+  - "[PROJECT_SPECIFIC: Question to answer]"
+  - "[PROJECT_SPECIFIC: Another question]"
+---
+```
+
+**Context:** [PROJECT_SPECIFIC: Why is this research needed?]
+
+**Expected Outcomes:** [PROJECT_SPECIFIC: What decisions will this inform?]
+
+---
+
+### Dependencies & Blockers
+
+Items waiting on external factors (upstream releases, third-party APIs, etc.)
+
+---
+
+#### BACKLOG-DB-001: [PROJECT_SPECIFIC: Blocked Item]
+
+```yaml
+---
+backlog_id: BACKLOG-DB-001
+title: "[PROJECT_SPECIFIC: Blocked Item]"
+category: blocked_external
+priority: p2
+added_at: [DATE]
+blocked_by_external: "[PROJECT_SPECIFIC: What external factor?]"
+expected_resolution: "[PROJECT_SPECIFIC: When might this unblock?]"
+---
+```
+
+**Description:** [PROJECT_SPECIFIC: What is blocked?]
+
+**When Unblocked:** [PROJECT_SPECIFIC: What should happen when this unblocks?]
+
+---
+
+## Backlog Template
+
+Use this template when adding new backlog items:
+
+```yaml
+---
+backlog_id: BACKLOG-XX-XXX
+title: "Short descriptive title"
+category: technical_debt | feature_idea | research | blocked_external
+priority: p3
+added_at: YYYY-MM-DD
+reason_deferred: "Why this isn't active yet"
+promotion_criteria:
+  - "Condition that would make this active"
+---
+```
+
+---
+
+## Promoting Items to Active Work
+
+When a backlog item is ready for active development:
+
+1. Create an epoch in `docs/ToDos.md` based on the backlog item
+2. Create or link a user story in `docs/UserStories.md` if needed
+3. Remove the item from this backlog (or mark as `promoted: true`)
+4. Add a note referencing the original backlog ID
+
+---
+
+## References
+
+- **Active Work:** `docs/ToDos.md`
+- **User Stories:** `docs/UserStories.md`
+- **Completed Work:** `docs/CompletedTasks.md`

--- a/docs/CompletedTasks.md
+++ b/docs/CompletedTasks.md
@@ -1,0 +1,108 @@
+---
+doc_type: completed_tasks
+version: "1.0"
+last_updated: [DATE]
+---
+
+# Completed Tasks
+
+<!--
+TEMPLATE USAGE INSTRUCTIONS:
+0. Update the frontmatter date when modifying this file
+   (Update version only for significant structural changes to template)
+1. Replace all [PROJECT_NAME] and [PROJECT_SPECIFIC] markers
+2. Move completed epochs here from docs/ToDos.md
+3. Maintain chronological order (newest at top)
+4. Remove these usage instruction comments before committing
+-->
+
+This document archives completed epochs and tasks for historical reference and progress tracking.
+
+**Document Structure**
+- Active work: `docs/ToDos.md`
+- User stories: `docs/UserStories.md`
+- Completed work: This file (`docs/CompletedTasks.md`)
+- Deferred work: `docs/Backlog.md`
+
+**For LLM assistance in multi-repo workspace:**
+See [Task Tracking Standard]([RELATIVE_PATH]/top-level-gitlab-profile/docs/common/task-tracking-standard.md)
+
+**For reference (GitLab):**
+[Task Tracking Standard](https://gitlab.com/smart-assets.io/gitlab-profile/-/blob/master/docs/common/task-tracking-standard.md)
+
+---
+
+## Completed Epochs
+
+<!-- Epochs are listed in reverse chronological order (newest first) -->
+
+---
+
+### EPOCH-XXX: [PROJECT_SPECIFIC: Epoch Title]
+
+```yaml
+---
+epoch_id: EPOCH-XXX
+title: "[PROJECT_SPECIFIC: Epoch Title]"
+status: complete
+priority: p1
+user_story: US-XXX
+completed_at: [DATE]
+completed_by: [SESSION_ID or contributor]
+mr_pr: "[PROJECT_SPECIFIC: MR/PR link if applicable]"
+tasks:
+  - id: TASK-XXX-1
+    title: "[PROJECT_SPECIFIC: Task 1 title]"
+    status: complete
+    completed_at: [DATE]
+
+  - id: TASK-XXX-2
+    title: "[PROJECT_SPECIFIC: Task 2 title]"
+    status: complete
+    completed_at: [DATE]
+---
+```
+
+**Summary:** [PROJECT_SPECIFIC: Brief summary of what was accomplished]
+
+**Key Changes:**
+- [PROJECT_SPECIFIC: Change 1]
+- [PROJECT_SPECIFIC: Change 2]
+
+**Lessons Learned:**
+- [PROJECT_SPECIFIC: What went well or what to do differently]
+
+---
+
+<!-- Add more completed epochs following the same format -->
+
+---
+
+## Completion Statistics
+
+<!-- Optional: Track metrics over time -->
+
+| Period | Epochs Completed | Tasks Completed | Notes |
+|--------|------------------|-----------------|-------|
+| [PROJECT_SPECIFIC: Period] | [Count] | [Count] | [Notes] |
+
+---
+
+## Archive Format
+
+When moving epochs from `docs/ToDos.md` to this file:
+
+1. Copy the entire epoch block (YAML frontmatter + context)
+2. Update `status: complete`
+3. Add `completed_at`, `completed_by`, and optionally `mr_pr`
+4. Update all task statuses to `complete` with `completed_at` dates
+5. Add a brief **Summary** section
+6. Optionally add **Key Changes** and **Lessons Learned**
+
+---
+
+## References
+
+- **Active Work:** `docs/ToDos.md`
+- **User Stories:** `docs/UserStories.md`
+- **Backlog:** `docs/Backlog.md`

--- a/docs/ToDos.md
+++ b/docs/ToDos.md
@@ -1,0 +1,164 @@
+---
+doc_type: todos
+version: "1.0"
+last_updated: [DATE]
+mr_status:
+  ready: false
+  target_branch: main
+---
+
+# Tasks and Epochs
+
+<!--
+TEMPLATE USAGE INSTRUCTIONS:
+0. Update the frontmatter date when modifying this file
+   (Update version only for significant structural changes to template)
+1. Replace all [PROJECT_NAME] and [PROJECT_SPECIFIC] markers
+2. Add new epochs using the YAML frontmatter format below
+3. Move completed epochs to docs/CompletedTasks.md
+4. Use /nextTask to find the next task to work on
+5. Use /implement to execute tasks with full context
+6. Remove these usage instruction comments before committing
+-->
+
+This document tracks implementation work through **epochs** (logical groupings of related tasks).
+
+**Document Structure**
+- Active work: This file (`docs/ToDos.md`)
+- User stories: `docs/UserStories.md`
+- Completed work: `docs/CompletedTasks.md`
+- Backlog: `docs/Backlog.md`
+
+**For LLM assistance in multi-repo workspace:**
+See [Task Tracking Standard]([RELATIVE_PATH]/top-level-gitlab-profile/docs/common/task-tracking-standard.md)
+
+**For reference (GitLab):**
+[Task Tracking Standard](https://gitlab.com/smart-assets.io/gitlab-profile/-/blob/master/docs/common/task-tracking-standard.md)
+
+---
+
+## MR/PR Tracking
+
+When all tasks in this file are complete and ready for merge, update the frontmatter:
+
+```yaml
+mr_status:
+  ready: true
+  target_branch: main
+  title: "feat: [PROJECT_SPECIFIC: MR title]"
+  description: |
+    ## Summary
+    - [Completed items]
+
+    ## Test plan
+    - [x] All tests passing
+  labels: ["feature", "enhancement"]
+```
+
+---
+
+## Active Epochs
+
+<!-- Epochs are ordered by priority. Work on the highest priority epoch first. -->
+
+---
+
+### EPOCH-001: [PROJECT_SPECIFIC: Epoch Title]
+
+```yaml
+---
+epoch_id: EPOCH-001
+title: "[PROJECT_SPECIFIC: Epoch Title]"
+status: pending          # pending | in_progress | blocked | review | complete
+priority: p1             # p0 (critical) | p1 (high) | p2 (medium) | p3 (low)
+user_story: US-XXX       # Link to user story in docs/UserStories.md
+blocked_by: []           # List of blocking epoch IDs
+created_at: [DATE]
+claimed_by: null         # Implementer ID: human-{email}, {tool}-session[-{id}], or {team}/{role}
+claimed_at: null
+tasks:
+  - id: TASK-001-1
+    title: "[PROJECT_SPECIFIC: Task 1 title]"
+    status: pending      # pending | in_progress | complete | blocked
+    acceptance:
+      - "[PROJECT_SPECIFIC: Acceptance criterion 1]"
+      - "[PROJECT_SPECIFIC: Acceptance criterion 2]"
+
+  - id: TASK-001-2
+    title: "[PROJECT_SPECIFIC: Task 2 title]"
+    status: pending
+    blocked_by: [TASK-001-1]  # Optional: task dependencies
+    acceptance:
+      - "[PROJECT_SPECIFIC: Acceptance criterion 1]"
+---
+```
+
+**Context:** [PROJECT_SPECIFIC: Why is this epoch needed? What problem does it solve?]
+
+**Scope:**
+- [PROJECT_SPECIFIC: What's included]
+- [PROJECT_SPECIFIC: What's explicitly excluded]
+
+**Notes:**
+- [PROJECT_SPECIFIC: Implementation notes, gotchas, references]
+
+---
+
+<!-- Add more epochs following the same format -->
+
+---
+
+## Epoch Template
+
+Use this template when adding new epochs:
+
+```yaml
+---
+epoch_id: EPOCH-XXX
+title: "Short descriptive title"
+status: pending
+priority: p2
+user_story: US-XXX
+blocked_by: []
+created_at: YYYY-MM-DD
+claimed_by: null         # Implementer ID: human-{email}, {tool}-session[-{id}], or {team}/{role}
+claimed_at: null
+tasks:
+  - id: TASK-XXX-1
+    title: "Task description"
+    status: pending
+    acceptance:
+      - "Measurable acceptance criterion"
+---
+```
+
+---
+
+## Task States
+
+| Status | Meaning | Next Action |
+|--------|---------|-------------|
+| `pending` | Not started | Available to claim |
+| `in_progress` | Being worked on | Continue or handoff |
+| `blocked` | Waiting on dependency | Check `blocked_by` |
+| `review` | Ready for review | Review and approve |
+| `complete` | Done | Move to CompletedTasks.md |
+
+---
+
+## Workflow
+
+1. **Find next task**: Use `/nextTask` to identify the highest priority unclaimed task
+2. **Claim task**: Set `claimed_by` using [Implementer Identification](../common/stigmergic-collaboration.md#implementer-identification) format and `status: in_progress`
+3. **Implement**: Use `/implement` to execute with full context
+4. **Complete**: Mark `status: complete` when acceptance criteria met
+5. **Move epoch**: When all tasks complete, move epoch to `docs/CompletedTasks.md`
+
+---
+
+## References
+
+- **User Stories:** `docs/UserStories.md`
+- **Completed Work:** `docs/CompletedTasks.md`
+- **Backlog:** `docs/Backlog.md`
+- **MR/PR Tracking Standard:** [docs/common/todos-mr_pr-tracking-standard.md]([RELATIVE_PATH]/top-level-gitlab-profile/docs/common/todos-mr_pr-tracking-standard.md)

--- a/docs/UserStories.md
+++ b/docs/UserStories.md
@@ -1,0 +1,94 @@
+---
+doc_type: user_stories
+version: "1.0"
+last_updated: "[DATE]"
+---
+
+# User Stories
+
+<!--
+TEMPLATE USAGE INSTRUCTIONS:
+0. Update frontmatter: set last_updated to current date, increment version for structural changes
+1. Add completed stories under "Completed Stories" section
+2. Add planned stories under "Planned Stories" section
+3. Move completed stories from "Planned" to "Completed" sections
+4. Update epoch links when implementation begins
+5. Check acceptance criteria as features are verified
+6. (Optional) Update reference URLs if using a fork with modified standards
+7. Remove these usage instruction comments before committing
+-->
+
+This document captures user stories that drive feature development. User stories are reverse-engineered from completed epochs and updated as new features are planned.
+
+**Document Structure**
+- Active stories: This file (`docs/UserStories.md`)
+- Implementation tracking: `docs/ToDos.md` (epochs and tasks)
+- Completed work: `docs/CompletedTasks.md`
+
+**Format:** Each story follows the standard template:
+> As a [persona], I want [capability] so that [benefit].
+
+**User Stories Standard Reference** (canonical):
+[user-stories-standard.md](https://gitlab.com/smart-assets.io/gitlab-profile/-/blob/master/docs/common/user-stories-standard.md)
+
+---
+
+## Completed Stories
+
+<!-- Add completed user stories here -->
+
+---
+
+## Planned Stories
+
+Stories below are candidates for future epochs. Move to "Completed Stories" when implemented.
+
+<!-- Add planned user stories here -->
+
+---
+
+## Story Template
+
+Use this template when adding new user stories:
+
+```markdown
+#### US-XXX: [Short Title]
+
+> As a **[persona]**, I want **[capability]** so that **[benefit]**.
+
+**Implemented in:** [EPOCH-ID or "Planned"]
+
+**Acceptance Criteria:**
+- [ ] Criterion 1
+- [ ] Criterion 2
+- [ ] Criterion 3
+
+**Completed:** [Date or "Planned"]
+```
+
+---
+
+## Relationship to Epochs
+
+User stories capture the **why** (user need and benefit). Epochs capture the **what** (technical implementation tasks).
+
+| Artifact | Purpose | Location |
+|----------|---------|----------|
+| User Story | Business/user need | `docs/UserStories.md` |
+| Epoch | Implementation scope | `docs/ToDos.md` |
+| Task | Technical work item | Nested in epoch YAML |
+| Acceptance Criteria | Definition of done | In user story |
+
+**Workflow:**
+1. Identify user need -> Create user story
+2. Design solution -> Create epoch with tasks
+3. Implement -> Work through tasks via `/nextTask` and `/implement`
+4. Complete -> Mark epoch complete, update story status
+
+---
+
+## References
+
+- **Task Tracking:** `docs/ToDos.md`
+- **Completed Work:** `docs/CompletedTasks.md`
+- **User Stories Standard** (canonical): [user-stories-standard.md](https://gitlab.com/smart-assets.io/gitlab-profile/-/blob/master/docs/common/user-stories-standard.md)

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -1,0 +1,91 @@
+# Release Process
+
+This project uses **SemVer** driven by `workspace.package.version` in the root
+`Cargo.toml`. Releases are cut on `main` by the `.github/workflows/release.yml`
+workflow.
+
+## Triggers
+
+The release workflow runs on:
+
+- **Nightly cron** at 06:00 UTC
+- **Every push to `main`** (typically a dev → main PR merge)
+- **Manual dispatch** via the Actions tab
+
+Every run is gated: if a git tag `v<workspace version>` already exists, the
+workflow exits without doing anything. Releases are cut only when the workspace
+version has been bumped since the last tag.
+
+## Contributor flow
+
+All release prep happens on `dev`. `main` is protected and the release workflow
+never writes to it.
+
+1. Merge the work you want to ship into `dev`.
+2. Bump `version` in `[workspace.package]` of the root `Cargo.toml`
+   (e.g. `0.1.0` → `0.2.0`).
+3. Run the changelog generator locally:
+
+   ```sh
+   ./AItools/scripts/generate-changelog.sh
+   ```
+
+   This reads the workspace version, collects commits since the last SemVer tag,
+   and inserts a `## [X.Y.Z] - YYYY-MM-DD` section into `CHANGELOG.md`.
+   Non-conventional commit messages are tolerated (they land under `### Changed`).
+
+   Edit the generated entries if you want cleaner release notes — the workflow
+   will use whatever is in `CHANGELOG.md` verbatim as the GitHub Release body.
+
+4. Commit and open a PR from `dev` to `main`.
+5. After merge, the release workflow will:
+   - Tag `vX.Y.Z` on `main`
+   - Create a GitHub Release using the `[X.Y.Z]` section of `CHANGELOG.md`
+   - Publish any `publish`-enabled crates to crates.io (see below)
+
+## crates.io publishing
+
+By default, every workspace member has `publish = false` as a safety measure.
+To make a crate publishable:
+
+1. Remove `publish = false` from its `Cargo.toml`.
+2. Ensure each intra-workspace path dependency also carries an explicit version:
+
+   ```toml
+   mettail-runtime = { path = "../runtime", version = "0.1.0" }
+   ```
+
+3. Confirm the crate has a `description`, `license`, and `repository` (most are
+   inherited from `[workspace.package]`).
+
+The publish job (`AItools/scripts/publish-crates.sh`) enumerates all publishable
+members, topologically sorts them by workspace dependencies, and runs
+`cargo publish -p <name>` for each. A 15-second sleep between publishes lets the
+crates.io index catch up before dependents publish.
+
+### Required repository secrets
+
+| Secret                  | Used for                                      |
+| ----------------------- | --------------------------------------------- |
+| `GITHUB_TOKEN`          | Automatic (creates tag + GitHub Release)      |
+| `CARGO_REGISTRY_TOKEN`  | `cargo publish` to crates.io                  |
+
+## Branch protection assumptions
+
+The workflow assumes `main` is protected:
+
+- Direct pushes disabled
+- PR required
+- (Optional) passing CI required
+
+The workflow never pushes commits to `main` — only annotated tags. If your
+protection rules block tag pushes from the `github-actions[bot]`, configure
+them to allow tag creation for that actor, or create a PAT and expose it as
+a repository secret used by the tag-push step.
+
+## Version-bump cadence
+
+There is no automated bump. Bumping is an intentional act by a contributor
+preparing a release PR. The nightly cron exists so that if a PR bumping the
+version gets merged during off-hours, the release is still cut without waiting
+for the next human push.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,0 +1,78 @@
+<!--
+ROADMAP TEMPLATE
+
+Usage:
+1. Copy this template to your project's docs/ directory as docs/roadmap.md
+   (or to the repo root as ROADMAP.md if docs/ is not used).
+2. Replace all <PLACEHOLDER> markers with actual content.
+3. Keep the frontmatter schema intact; consuming tooling depends on it.
+4. Update `updated:` whenever the file is edited.
+5. Remove these usage instruction comments before committing.
+
+This template is governed by:
+  docs/common/roadmap-release-normalization-standard.md
+
+Required behavior:
+- Nearest-term releases MUST carry a calendar `target_date` (YYYY-MM-DD).
+- Long-horizon entries MAY use the `YYYY-QN` quarter form.
+- Versions MUST follow strict SemVer: vMAJOR.MINOR.PATCH[-pre-release].
+-->
+---
+doc_type: roadmap
+repo: <repo-name>
+updated: YYYY-MM-DD
+horizon_months: 6
+owners:
+  - github: <maintainer-username>
+    email: <optional@address>
+releases:
+  - version: vX.Y.Z
+    target_date: YYYY-MM-DD
+    milestone: "vX.Y.Z — <theme>"
+    status: planned
+    theme: <one-line description>
+    notes: <optional context>
+  - version: vX.Y+1.0
+    target_date: YYYY-QN
+    milestone: "vX.Y+1.0 — <theme>"
+    status: planned
+    theme: <one-line description>
+---
+
+# <Repo Name> Roadmap
+
+> This file is governed by the [Roadmap, Release Date, and Version Normalization Standard](../common/roadmap-release-normalization-standard.md).
+> Update the `updated:` frontmatter field whenever this file is edited.
+> Nearest-term releases MUST carry a calendar `target_date`; long-horizon entries MAY use the `YYYY-QN` quarter form.
+
+## Current Focus
+
+<Short paragraph describing what is actively being worked on and how it maps to the nearest release.>
+
+## Upcoming Releases
+
+### vX.Y.Z — <theme>
+
+- **Target:** YYYY-MM-DD
+- **Milestone:** [vX.Y.Z — <theme>](<milestone-url>)
+- **Status:** planned | in_progress
+
+<Scope summary: what is in, what is out, and known risks.>
+
+### vX.Y+1.0 — <theme>
+
+- **Target:** YYYY-QN
+- **Milestone:** _to be created_
+- **Status:** planned
+
+<Scope summary.>
+
+## Out of Scope / Deferred
+
+- <Item> — <reason for deferral>
+
+## Change Log
+
+| Date | Change |
+|------|--------|
+| YYYY-MM-DD | Initial roadmap created from roadmap.md.template |

--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -3,29 +3,24 @@
 # Install: git config core.hooksPath hooks/
 set -e
 
-# Verify the configured linker is available before running cargo commands.
-# .cargo/config.toml requires lld on macOS and mold on Linux.
-check_linker() {
-    case "$(uname -s)" in
-        Darwin)
-            if ! command -v lld >/dev/null 2>&1; then
-                echo "WARNING: lld not found. Install: brew install llvm"
-                echo "  Then add to PATH: export PATH=\"/opt/homebrew/opt/llvm/bin:\$PATH\""
-                echo "  Skipping pre-commit checks (cargo cannot link without lld)."
-                exit 0
-            fi
-            ;;
-        Linux)
-            if ! command -v mold >/dev/null 2>&1; then
-                echo "WARNING: mold not found. Install: sudo apt install mold"
-                echo "  Skipping pre-commit checks (cargo cannot link without mold)."
-                exit 0
-            fi
-            ;;
-    esac
-}
-
-check_linker
+# Require the configured linker (.cargo/config.toml).
+case "$(uname -s)" in
+    Darwin)
+        if ! command -v lld >/dev/null 2>&1; then
+            echo "ERROR: lld not found. Required by .cargo/config.toml"
+            echo "  brew install llvm"
+            echo "  export PATH=\"/opt/homebrew/opt/llvm/bin:\$PATH\""
+            exit 1
+        fi
+        ;;
+    Linux)
+        if ! command -v mold >/dev/null 2>&1; then
+            echo "ERROR: mold not found. Required by .cargo/config.toml"
+            echo "  sudo apt install mold"
+            exit 1
+        fi
+        ;;
+esac
 
 echo "=== pre-commit: cargo fmt ==="
 cargo fmt --all -- --check

--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -3,6 +3,30 @@
 # Install: git config core.hooksPath hooks/
 set -e
 
+# Verify the configured linker is available before running cargo commands.
+# .cargo/config.toml requires lld on macOS and mold on Linux.
+check_linker() {
+    case "$(uname -s)" in
+        Darwin)
+            if ! command -v lld >/dev/null 2>&1; then
+                echo "WARNING: lld not found. Install: brew install llvm"
+                echo "  Then add to PATH: export PATH=\"/opt/homebrew/opt/llvm/bin:\$PATH\""
+                echo "  Skipping pre-commit checks (cargo cannot link without lld)."
+                exit 0
+            fi
+            ;;
+        Linux)
+            if ! command -v mold >/dev/null 2>&1; then
+                echo "WARNING: mold not found. Install: sudo apt install mold"
+                echo "  Skipping pre-commit checks (cargo cannot link without mold)."
+                exit 0
+            fi
+            ;;
+    esac
+}
+
+check_linker
+
 echo "=== pre-commit: cargo fmt ==="
 cargo fmt --all -- --check
 

--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -1,0 +1,13 @@
+#!/bin/sh
+# MeTTaIL pre-commit hook
+# Install: git config core.hooksPath hooks/
+set -e
+
+echo "=== pre-commit: cargo fmt ==="
+cargo fmt --all -- --check
+
+echo "=== pre-commit: cargo clippy ==="
+cargo clippy --all-targets --all-features -- -D warnings
+
+echo "=== pre-commit: cargo test ==="
+cargo test --all-features --workspace --quiet

--- a/hooks/pre-push
+++ b/hooks/pre-push
@@ -3,28 +3,24 @@
 # Install: git config core.hooksPath hooks/
 set -e
 
-# Verify the configured linker is available before running cargo commands.
-check_linker() {
-    case "$(uname -s)" in
-        Darwin)
-            if ! command -v lld >/dev/null 2>&1; then
-                echo "WARNING: lld not found. Install: brew install llvm"
-                echo "  Then add to PATH: export PATH=\"/opt/homebrew/opt/llvm/bin:\$PATH\""
-                echo "  Skipping pre-push checks (cargo cannot link without lld)."
-                exit 0
-            fi
-            ;;
-        Linux)
-            if ! command -v mold >/dev/null 2>&1; then
-                echo "WARNING: mold not found. Install: sudo apt install mold"
-                echo "  Skipping pre-push checks (cargo cannot link without mold)."
-                exit 0
-            fi
-            ;;
-    esac
-}
-
-check_linker
+# Require the configured linker (.cargo/config.toml).
+case "$(uname -s)" in
+    Darwin)
+        if ! command -v lld >/dev/null 2>&1; then
+            echo "ERROR: lld not found. Required by .cargo/config.toml"
+            echo "  brew install llvm"
+            echo "  export PATH=\"/opt/homebrew/opt/llvm/bin:\$PATH\""
+            exit 1
+        fi
+        ;;
+    Linux)
+        if ! command -v mold >/dev/null 2>&1; then
+            echo "ERROR: mold not found. Required by .cargo/config.toml"
+            echo "  sudo apt install mold"
+            exit 1
+        fi
+        ;;
+esac
 
 # ls-remote race guard: skip if local HEAD already matches remote.
 _qc_local_head=$(git rev-parse HEAD)

--- a/hooks/pre-push
+++ b/hooks/pre-push
@@ -3,6 +3,29 @@
 # Install: git config core.hooksPath hooks/
 set -e
 
+# Verify the configured linker is available before running cargo commands.
+check_linker() {
+    case "$(uname -s)" in
+        Darwin)
+            if ! command -v lld >/dev/null 2>&1; then
+                echo "WARNING: lld not found. Install: brew install llvm"
+                echo "  Then add to PATH: export PATH=\"/opt/homebrew/opt/llvm/bin:\$PATH\""
+                echo "  Skipping pre-push checks (cargo cannot link without lld)."
+                exit 0
+            fi
+            ;;
+        Linux)
+            if ! command -v mold >/dev/null 2>&1; then
+                echo "WARNING: mold not found. Install: sudo apt install mold"
+                echo "  Skipping pre-push checks (cargo cannot link without mold)."
+                exit 0
+            fi
+            ;;
+    esac
+}
+
+check_linker
+
 # ls-remote race guard: skip if local HEAD already matches remote.
 _qc_local_head=$(git rev-parse HEAD)
 _qc_remote_head=$(git ls-remote origin "$(git symbolic-ref HEAD)" 2>/dev/null | awk '{print $1}')

--- a/hooks/pre-push
+++ b/hooks/pre-push
@@ -1,0 +1,25 @@
+#!/bin/sh
+# MeTTaIL pre-push hook
+# Install: git config core.hooksPath hooks/
+set -e
+
+# ls-remote race guard: skip if local HEAD already matches remote.
+_qc_local_head=$(git rev-parse HEAD)
+_qc_remote_head=$(git ls-remote origin "$(git symbolic-ref HEAD)" 2>/dev/null | awk '{print $1}')
+if [ -n "$_qc_remote_head" ] && [ "$_qc_local_head" = "$_qc_remote_head" ]; then
+    echo "Already up to date with remote. Skipping pre-push checks."
+    exit 0
+fi
+
+echo "=== pre-push: cargo test ==="
+_test_output=$(cargo test --all-features --workspace -q 2>&1) || { echo "$_test_output"; exit 1; }
+_passed=$(echo "$_test_output" | grep -oE '[0-9]+ passed' | awk '{s+=$1} END{print s+0}')
+_failed=$(echo "$_test_output" | grep -oE '[0-9]+ failed' | awk '{s+=$1} END{print s+0}')
+if [ "$_failed" -gt 0 ]; then
+    echo "$_test_output"
+    exit 1
+fi
+echo "ok. ${_passed} passed"
+
+echo "=== pre-push: cargo build --release ==="
+cargo build --release

--- a/languages/Cargo.toml
+++ b/languages/Cargo.toml
@@ -1,7 +1,12 @@
 [package]
 name = "mettail-languages"
-version = "0.1.0"
-edition = "2021"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+publish = false
 
 # Library only - no binaries
 # Examples are in workspace examples/ directory

--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -1,13 +1,14 @@
 [package]
 name = "mettail-macros"
-version = "0.1.0"
-edition = "2021"
-authors = ["MeTTaIL Contributors"]
-license = "MIT"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
 description = "Procedural macros for MeTTaIL - a meta-language framework for defining formal languages"
-repository = "https://github.com/f1r3fly-io/mettail-rust"
-homepage = "https://github.com/f1r3fly-io/mettail-rust"
 readme = "../README.md"
+publish = false
 
 [lib]
 proc-macro = true

--- a/prattail/Cargo.toml
+++ b/prattail/Cargo.toml
@@ -4,7 +4,10 @@ version.workspace = true
 edition.workspace = true
 authors.workspace = true
 license.workspace = true
+repository.workspace = true
+homepage.workspace = true
 description = "PraTTaIL: Pratt + Recursive Descent parser generator with automata-optimized lexing for MeTTaIL"
+publish = false
 
 [features]
 ## WFST-based prediction, lattice, recovery, and composition modules.

--- a/query/Cargo.toml
+++ b/query/Cargo.toml
@@ -1,8 +1,13 @@
 [package]
 name = "mettail-query"
-version = "0.1.0"
-edition = "2021"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
 description = "Runtime query interpreter for MeTTaIL: parse and execute Datalog-style rules over Ascent results"
+publish = false
 
 [dependencies]
 ascent_syntax_export = { path = "../ascent_syntax_export" }

--- a/repl/Cargo.toml
+++ b/repl/Cargo.toml
@@ -1,7 +1,12 @@
 [package]
 name = "mettail-repl"
-version = "0.1.0"
-edition = "2021"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+publish = false
 
 [[bin]]
 name = "mettail"

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -1,15 +1,16 @@
 [package]
 name = "mettail-runtime"
-version = "0.1.0"
-edition = "2021"
-authors = ["MeTTaIL Contributors"]
-license = "MIT"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
 description = "Runtime support library for MeTTaIL - provides variable binding and substitution utilities"
-repository = "https://github.com/your-username/mettail-rust"
-homepage = "https://github.com/your-username/mettail-rust"
 keywords = ["language", "runtime", "binding", "substitution"]
 categories = ["development-tools"]
 readme = "../README.md"
+publish = false
 
 [dependencies]
 moniker = { workspace = true }


### PR DESCRIPTION
  ## Summary

  - **Workspace metadata unification**: All member crates now use `[workspace.package]` inheritance for version/edition/authors/license/repository/homepage. Repository URL standardized to `F1R3FLY-io/mettail-rust`.
   All members default to `publish = false` (opt-in per crate).
  - **Release workflow** (`.github/workflows/release.yml`): Triggers on nightly cron (06:00 UTC), push to `main`, and manual dispatch. Gates on workspace version tag absence — only cuts a release when `Cargo.toml`
  version has been bumped. Creates annotated tag, GitHub Release from CHANGELOG section, publishes opt-in crates.
  - **Changelog tooling** (`AItools/scripts/generate-changelog.sh`): SemVer-driven port of SA workspace script. Reads version from `Cargo.toml`, categorizes conventional commits, tolerates non-conforming messages.
  - **Crates.io publish helper** (`AItools/scripts/publish-crates.sh`): Topologically sorts publishable workspace members and `cargo publish`es in dependency order. Currently a no-op since all crates have `publish
  = false`.
  - **CI coverage for `dev`**: Extended `ci.yml` push/PR triggers to include `dev` branch.
  - **Task tracking scaffolding** (`docs/`): Seeded via `/harmonize`.

  ## Reviewer notes

  - **`CARGO_REGISTRY_TOKEN` secret** has not been added yet — will be configured after this PR merges. The publish-crates job will simply fail gracefully until then.
  - **Branch protection** on `main` is now enabled (PR-required, no direct pushes). The release workflow only pushes annotated tags, not commits.
  - The release workflow uses `GITHUB_TOKEN` (automatic) for tag creation and GitHub Release. If tag pushes are blocked by branch protection rules, the `github-actions[bot]` actor needs to be allowed for tag
  creation.

  ## Test plan

  - [ ] Verify `cargo metadata --no-deps` still parses cleanly after Cargo.toml unification
  - [ ] Verify `cargo test --all-features --workspace` passes
  - [ ] Verify `generate-changelog.sh --dry-run` produces expected output
  - [ ] Verify `publish-crates.sh` reports "No publishable crates" (all `publish = false`)
  - [ ] Verify release workflow YAML is valid and all steps use env-var patterns (no direct expression injection)
  - [ ] Confirm CI triggers on both `main` and `dev` branches
