### PR TITLE
Unification premises

### DIFF
--- a/docs/design/exploring/unification-premises-for-pattern-comm.md
+++ b/docs/design/exploring/unification-premises-for-pattern-comm.md
@@ -67,7 +67,7 @@ Patterns are **`Proc`** values built from **constructors**. At minimum:
 
 ### PraTT / REPL sugar
 
-REPL examples in this repo historically use **`for(a -> x){ … }`** style strings (see [repl examples](../../../repl/src/examples/rhocalc.rs)). **Proposal:** keep that sugar; extend the grammar so **the binding after `->`** can be a **`Proc` pattern** (e.g. **`for(c -> $x){ … }`**, **`for(c -> pair($u, $v)){ … }`**), lowering to the same **`PInputs`**-like constructor as concrete **`( c ? … ).{ … }`** form.
+REPL examples in this repo historically used **`for(channel -> value){ … }`** style strings (see [repl examples](../../../repl/src/examples/rhocalc.rs)). The target syntax here is **`for(pattern <- channel){ … }`**; extend the grammar so the left side can be a **`Proc` pattern** (e.g. **`for($x <- c){ … }`**, **`for(pair($u, $v) <- c){ … }`**), lowering to the same **`PInputs`**-like constructor as concrete **`( c ? … ).{ … }`** form.
 
 End-to-end walkthroughs (**`rhocalc.rs` → user program → channel data → output**) are in [Worked examples (four-part layout)](#worked-examples-four-part-layout).
 
@@ -481,7 +481,7 @@ Receive syntax binds **`Name`** parameters per channel, not arbitrary **`Proc`**
 **2. User’s program**
 
 ```text
-{ a!(0) | for(a -> x){ *(x) } }
+{ a!(0) | for(x <- a){ *(x) } }
 ```
 
 **3. Data on the channel**  
@@ -510,7 +510,7 @@ CommPat . | unifies(pat, q)
 **2. User’s program**
 
 ```text
-{ c!(7) | for(c -> $x){ int($x, 64) } }
+{ c!(7) | for($x <- c){ int($x, 64) } }
 ```
 
 **3. Data on the channel**  
@@ -533,7 +533,7 @@ PPair . u:Proc, v:Proc |- "pair" "(" u "," v ")" : Proc;
 **2. User’s program**
 
 ```text
-{ c!(pair(1, 2)) | for(c -> pair($u, $v)){ int($u, 64) } }
+{ c!(pair(1, 2)) | for(pair($u, $v) <- c){ int($u, 64) } }
 ```
 
 **3. Data on the channel**  
@@ -552,14 +552,14 @@ Same as Scenario B.
 **2. User’s program**
 
 ```text
-{ c!("hi") | for(c -> pair($u, $v)){ int($u, 64) } }
+{ c!("hi") | for(pair($u, $v) <- c){ int($u, 64) } }
 ```
 
 **3. Data on the channel**  
 **Message:** **`"hi"`** (**`Proc`** string). **Pattern:** **`pair($u, $v)`** — requires **`PPair`** head.
 
 **4. Output and explanation**  
-**`unifies_proc`** fails; **`CommPat`** does not consume this pair; **no exception**. (With **`for(c -> $x)`** instead, **`"hi"`** would match an accept-all **`$x`**.)
+**`unifies_proc`** fails; **`CommPat`** does not consume this pair; **no exception**. (With **`for($x <- c)`** instead, **`"hi"`** would match an accept-all **`$x`**.)
 
 ---
 
@@ -571,7 +571,7 @@ Same as Scenario B.
 **Success — 2. User’s program**
 
 ```text
-{ c!(pair(3, 3)) | for(c -> pair($x, $x)){ int($x, 64) } }
+{ c!(pair(3, 3)) | for(pair($x, $x) <- c){ int($x, 64) } }
 ```
 
 **3. Data on the channel**  
@@ -583,7 +583,7 @@ Same as Scenario B.
 **Failure — 2. User’s program**
 
 ```text
-{ c!(pair(3, 4)) | for(c -> pair($x, $x)){ int($x, 64) } }
+{ c!(pair(3, 4)) | for(pair($x, $x) <- c){ int($x, 64) } }
 ```
 
 **3. Data on the channel**  
@@ -607,7 +607,7 @@ Comm2 . | unifies(pat1, q1), unifies(pat2, q2)
 **2. User’s program**
 
 ```text
-{ a!(1) | b!(pair(2, 3)) | for(a -> $m){ for(b -> pair($u, $v)){ int($u, 64) } } }
+{ a!(1) | b!(pair(2, 3)) | for($m <- a){ for(pair($u, $v) <- b){ int($u, 64) } } }
 ```
 
 **3. Data on the channel**  

--- a/docs/design/exploring/unification-premises-for-pattern-comm.md
+++ b/docs/design/exploring/unification-premises-for-pattern-comm.md
@@ -1,6 +1,24 @@
 # Unification Premises for Pattern-Based COMM
 
-## Goal
+## Context: problem this work solves
+
+The team is formalizing **Rholang semantics** inside a logical framework (rhocalc / graph-structured lambda theory). The immediate goal is to define **unification premises** needed for **pattern-based COMM** (the communication reduction).
+
+In Rholang, communication has the familiar shape:
+
+```text
+for(pattern <- channel) { P }  |  channel!(value)
+```
+
+A COMM reduction is justified **only when**:
+
+- the sent value **matches** the receive pattern,
+- bindings are produced,
+- substitutions are applied **safely** (capture-avoiding).
+
+So COMM requires a **formal pattern matching + unification** story, not ad hoc matching in the interpreter only. This document specifies the **logical foundations** and the **staged implementation** that fits the existing Ascent + macro pipeline.
+
+## Goal (engineered rule shape)
 
 Enable relation-based pattern matching in rewrite premises so COMM-style rules can be guarded by unification:
 
@@ -10,7 +28,125 @@ Comm . | pattern unifies received
      ~> (PPar {(apply_pattern pattern received body), ...rest})
 ```
 
-The intent is to keep "does this match?" inside Ascent/Datalog fixpoint computation, while keeping binding extraction and substitution in deterministic Rust runtime code.
+The intent is to keep “does this match?” inside Ascent/Datalog fixpoint computation, while keeping binding extraction and substitution in deterministic Rust runtime code (see [Logical vs staged realization](#logical-vs-staged-realization)).
+
+## Key design decision: explicit variables instead of implicit binding
+
+### Two representations
+
+**(A) Closed lambda-theory encoding (implicit binding).** Variables are handled via meta-theoretical binding (e.g. “`lambda x . body`” style). This is simple for bare abstractions but **does not scale** to rich patterns: multiple simultaneous bindings, structured decomposition, and capture avoidance become awkward.
+
+**(B) Explicit variable representation (chosen).** Variables are **syntax**:
+
+- dedicated productions such as `Var(x)` (name indexed suitably for the object language),
+- abstractions such as `Abs(x, body)` (or equivalent) alongside constructors.
+
+Pattern matching then manipulates the same term algebra as the rest of the theory: **programmable substitution**, extensible pattern constructors, unification rules, and pattern environments are all tractable.
+
+Pattern receives bind **during matching**, not only during parsing; explicit `Var` nodes make that semantics first-class.
+
+### Capture-avoiding substitution as a semantic primitive
+
+Pattern matching produces bindings `{ x ↦ v, … }`. COMM must then apply `P[σ]` to the continuation. So substitution is not an informal helper—it is a **core semantic primitive**.
+
+**Logical picture (relational):** a 4-place relation (schematically):
+
+```text
+subst(term, variable, replacement, result)
+```
+
+| Argument     | Role |
+| ------------ | ---- |
+| `term`       | expression before replacement |
+| `variable`   | variable being replaced |
+| `replacement`| inserted value |
+| `result`     | capture-avoiding result |
+
+Conceptually `subst(T, v, R) = T′`, but **encoded in the logic** so reductions and future behavioral predicates can reason about it uniformly.
+
+**Implementation note:** rhocalc already relies on Rust-side substitution utilities; the relational formulation is the **spec** those utilities should satisfy. Codegen may continue to call consolidated `subst`/`apply` helpers while the theory documents the intended relation.
+
+## Formal COMM sketch (premises + conclusion)
+
+Although concrete syntax is fixed by the embedding, the judgement shape is:
+
+```text
+Send(channel, value)
+  |
+Receive(channel, pattern, continuation)
+  ────────────────────────────────────────────
+  if unify(pattern, value, σ)
+
+  →  continuation with σ applied  (capture-avoiding)
+```
+
+Implementation requires three cooperating parts:
+
+1. **Pattern representation** in the object language (including wildcards/vars/structure as the grammar allows).
+2. **Unification** as logical premises (eligibility for COMM).
+3. **Substitution** application on the continuation once unification succeeds.
+
+## Unification premises — conceptual breakdown
+
+### Structural matching
+
+Patterns must decompose values structurally (wildcards, variables, tuples/constructors, literals as the language defines).
+
+| Pattern | Value | Outcome |
+| ------- | ----- | ------- |
+| wildcard | anything | success |
+| variable `x` | `v` | bind `x ↦ v` |
+| structured | same shape | recurse |
+
+At the specification level this is **`unify(Pattern, Value, Env)`** with `Env` accumulated left-to-right (or by a fixed recursion strategy).
+
+### Environment accumulation
+
+Bindings form a finite map (or list-encoded map) `Env = { x ↦ v, y ↦ w, … }`. Unification **builds** this structure during recursion.
+
+### Consistency constraint
+
+Repeated pattern variables impose equality on matched pieces:
+
+- `(x, x)` vs `(1, 1)` — OK if both bindings agree.
+- `(x, x)` vs `(1, 2)` — fail.
+
+The implementation must reject inconsistent merges deterministically.
+
+### Integration with substitution
+
+After `σ` is determined, the COMM conclusion uses **capture-avoiding** multi-substitution into the continuation, grounded in `subst`/multi-`subst` as already used in the runtime.
+
+## Logical architecture
+
+Rough pipeline from syntax to reduction:
+
+```text
+Syntax layer
+   → Explicit variables (Var / Abs / …)
+   → Unification premises (eligibility)
+   → Binding environment σ
+   → Capture-avoiding substitution
+   → COMM reduction (plus congruence/engine as today)
+```
+
+## Relationship to behavioral types
+
+Later work on **behavioral types** will treat many properties as **predicates over runtime behavior** of terms. Pattern unification is foundational: it lets the logic talk about **which reductions are possible** and **what bindings arise**, which feeds runtime reasoning and Ascent/Datalog-style inference over predicates.
+
+## Logical vs staged realization
+
+**Fully relational story (semantics):**
+
+- `unify(pattern, value, env)` — three-place (pattern, value, binding environment).
+- `subst(term, var, repl, result)` — four-place, binder-aware, capture-avoiding.
+
+**Staged story (current engineering plan in this repo):**
+
+- **`unifies_<cat>(pattern, value)`** — binary relation in Ascent: “match is possible” (directional pattern → value). The environment `σ` is **not** carried in the relation tuple.
+- **`apply_pattern(pattern, value, body) -> Option<_>`** — after the premise succeeds, **reconstruct** bindings by a deterministic walk and apply multi-substitution to `body`.
+
+This split reuses existing premise scheduling (`Premise → Condition`, `generate_condition_clauses`) and keeps term construction in Rust. A future refinement could surface `unify(·,·,σ)` in Datalog if behavioral rules need to mention `σ` explicitly; the conceptual sections above still describe the intended meaning.
 
 ## Current Baseline
 
@@ -20,18 +156,18 @@ Today, premise relations already participate in fixpoint scheduling via generate
 - Premise lowering is handled through `Premise -> Condition` and `generate_condition_clauses` in `macros/src/logic/rules.rs`.
 - Ascent evaluates premise relations to fixpoint before dependent rewrites fire.
 
-This is exactly the mechanism needed for unification premises: add `unifies_<cat>(pattern, value)` and reuse the same condition-generation plumbing.
+This is the mechanism reused for unification premises: add `unifies_<cat>(pattern, value)` and plug it into the same condition-generation plumbing.
 
 ## Design Overview
 
-The feature is split into two responsibilities:
+The **staged** feature is split into two responsibilities:
 
-1. **Datalog relation (`unifies_`*)** answers whether a pattern unifies with a value.
+1. **Datalog relation (`unifies_`*)** answers whether a pattern unifies with a value (eligibility).
 2. **Runtime function (`apply_pattern`)** computes bindings and performs substitution once a rule fires.
 
-This mirrors existing architecture where relations express logical preconditions and Rust handles deterministic term construction/evaluation.
+This mirrors the architecture where relations express logical preconditions and Rust handles deterministic term construction/evaluation.
 
-## Proposed Semantics
+## Proposed Semantics (binary relation layer)
 
 For each category `Cat` (for example `Proc`, `Name`), introduce:
 
@@ -39,17 +175,117 @@ For each category `Cat` (for example `Proc`, `Name`), introduce:
 relation unifies_cat(Cat, Cat);
 ```
 
-Read as: "`lhs` unifies with `rhs`".
+Read as: directional **pattern** (first argument) **matches** **value** (second argument).
 
 High-level semantics:
 
 - Constructor-to-constructor unification succeeds when labels match and all corresponding child positions unify.
-- Pattern free variables in designated "pattern position" unify with any value at that position.
+- Pattern free variables in designated “pattern position” unify with any value at that position.
 - Collection constructors unify via multiset matching (see dedicated section).
 - Optional equational closure may be layered so unification sees equation-equivalent values.
 
-## Macro and Runtime Changes
+## Implementation roadmap (foundational sequence)
 
+The following steps track the **logical** dependencies; they align with but are not identical to [Rollout Plan](#rollout-plan) phases (which are ordered for incremental shipping).
+
+1. **Extend syntax** — explicit variable nodes (`Var` / analogous) so patterns share the same representation as matchable terms.
+2. **Define substitution** — specify (and implement against) capture-avoiding `subst`; keep binder-aware recursion consistent with the relational contract.
+3. **Pattern AST** — wildcards, variables, structured constructors, literals as required by rhocalc.
+4. **Unification** — structural rules + duplicate-variable consistency; in Ascent: generated `unifies_<cat>` plus premise lowering.
+5. **Environment** — in the staged design, bindings are produced inside `apply_pattern`; if moving to a 3-place `unify`, env becomes a relation argument.
+6. **Apply to continuation** — COMM RHS uses substitution / `apply_pattern` on the receive body.
+7. **Encode COMM rule** — rewrite fires iff unification premises hold (and channel agreement, etc.).
+
+## Design decisions and recommendations
+
+This section records **investigation-backed options** for four choices that were open during design. It is grounded in the current repo: how premises parse (`macros/src/ast/language.rs`), how COMM is written today (`languages/src/rhocalc.rs`), and how `eval` lowers to substitution (`PatternTerm::MultiSubst` in the pattern parser).
+
+### 1. Surface syntax for the unification premise
+
+**Current parser behavior.** A premise starts with an identifier; the **next** token must be `#` (freshness), `~>` (congruence), `(` (relation call), or `.*map(` (forall). Anything else is rejected. So any new form must extend this disambiguation and stay distinct from `~>` and equation/rewrite judgements.
+
+```862:926:macros/src/ast/language.rs
+/// Parse a single premise in the propositional context
+/// Grammar: freshness | congruence | relation_query | forall
+///   freshness  ::= ident "#" (ident | "..." ident)
+///   congruence ::= ident "~>" ident
+///   relation   ::= ident "(" (ident ("," ident)*)? ")"
+///   forall     ::= ident "." "*" "map" "(" "|" ident "|" premise ")"
+fn parse_premise(input: ParseStream) -> SynResult<Premise> {
+    let first = input.parse::<Ident>()?;
+    // ... branches on #, ~>, (, . ...
+```
+
+| Option | Shape | Pros | Cons |
+| ------ | ----- | ---- | ---- |
+| **A** | `unifies(pat, val)` or `unifies_proc(pat, val)` | Matches “relation call” style next to `env_var(x,v)` | If implemented as a generic `RelationQuery`, needs a **reserved** builtin name and special lowering |
+| **B** | `pat ~? val` | Visually paired with `~>` | Extra lexer/parser work: `~` must not commit to `~>`; authors learn another operator |
+| **C** | `pat unifies val` | Reads like informal logic | New branch (ident then keyword `unifies`); odd if a metavar were named `unifies` (rare in this DSL) |
+| **D** | Surface looks like **A**, AST is always **`Premise::Unification`** (not a user-defined relation) | Clear separation: user relations vs primitive; good errors in codegen | Slight conceptual duplication with `rel(args)` look |
+
+**Recommendation.** **D** with concrete surface **`unifies(pat, val)`**, implemented by recognizing `unifies` as a **keyword** in premise position and parsing into **`Premise::Unification { pattern, value }`** (not `RelationQuery`). Rationale: fits the existing conjunction-of-premises story, avoids `~?` / `~>` edge cases, and keeps lowering explicit.
+
+Optional: if category must be visible for disambiguation, reserve `unifies_proc` / `unifies_name`; the macro may still infer category from metavar types when possible.
+
+### 2. Binary `unifies_cat(pattern, value)` vs three-place `unify(pattern, value, env)` in Datalog
+
+**Pipeline context.** Congruence lowers to `rw_<cat>(S, T)`; premises become `Condition` clauses. There is no generic “environment” tuple in that path today. On the RHS, multi-arg `eval` already desugars to **`MultiSubst`** (substitution application after matching), i.e. bindings are realized when building the result term.
+
+**Options.**
+
+| Option | Meaning | Pros | Cons |
+| ------ | ------- | ---- | ---- |
+| **A** | Binary `unifies_cat(p, v)` in Ascent; `apply_pattern` / `MultiSubst` rebuilds `σ` | Smallest change; matches staged design; enough for “COMM fires or not” | Rules that must quantify over the **exact** `σ` cannot see it in Datalog |
+| **B** | Three-place `unifies_proc(p, v, env)` with a concrete `Env` type | `σ` is first-class in fixpoint; natural for rich behavioral typing | Must design `Env` representation, more clauses, stratification and size risk |
+| **C** | Binary for rewrites plus auxiliary relations (e.g. per-binding tuples) only where typing needs them | Incremental | Two stories to test; overlaps with `apply_pattern` |
+
+**Recommendation.** **A for Phase 1–2:** binary `unifies_<cat>` for eligibility, `apply_pattern` (or existing `eval`/`MultiSubst` path) for `σ`. Adopt **B or C** only when a **concrete** typing or logic rule needs `σ` in a premise—not speculatively. If B is added later, choose `Env` encoding by what Ascent can stratify and what `Proc`/`Name` can index cheaply.
+
+### 3. Scope of the first pattern-based COMM (multiset / `PPar` inside pattern)
+
+**Baseline in rhocalc.** The existing **`Comm`** rule already matches a **parallel bag** with structured LHS syntax (`PPar`, `PInputs`, `#zip`/`*map` over outputs). The receive side is **`PInputs`** with **`^[xs].p`**: names per channel, not arbitrary **`Proc`** patterns in receive position.
+
+```821:824:languages/src/rhocalc.rs
+        Comm . |- (PPar {(PInputs ns cont), *zip(ns,qs).*map(|n,q| (POutput n q)), ...rest})
+            ~> (PPar {(eval cont qs.*map(|q| (NQuote q))), ...rest});
+```
+
+```76:77:languages/src/rhocalc.rs
+        PInputs . ns:Vec(Name), ^[xs].p:[Name* -> Proc]
+        |- "(" *zip(ns,xs).*map(|n,x| n "?" x).*sep(",") ")" "." "{" p "}" : Proc ;
+```
+
+**Multiset** complexity is already on composition for **outputs**; the gap for “pattern COMM” is **payload / receive patterns** and unification, not “first contact with bags.”
+
+**Options.**
+
+| Option | Scope | Pros | Cons |
+| ------ | ----- | ---- | ---- |
+| **A** | Minimal: e.g. single channel or keep names only; strict structural **`Proc`** patterns **without** `PPar` inside pattern | Fast to ship | Skips nested parallelism in patterns |
+| **B** | Full multiset-in-pattern (pattern contains a bag) | Matches full Rholang eventually | NP-hard matching; belongs in collection-unification phase |
+| **C** | **Multi-channel** as today; evolve each receive arm toward **`n ? pattern`** ( **`Proc`** pattern per bind site) | Fits current rule shape; closest incremental step to Rholang | Requires grammar + `PInputs` change + unification per arm |
+
+**Recommendation.** **C** as the first pattern-COMM milestone, with patterns restricted to **Phase-1 structural unification** (constructors, variables, literals). Defer **B** to the dedicated [Collection Pattern Matching](#collection-pattern-matching-hard-part) phase.
+
+### 4. Explicit `Var` in `Proc` (vs other representations)
+
+**Current state.** Many native/nominal categories get generated **`Var`** variants and eval-time “must substitute first” behavior. **`Proc`** in rhocalc is a large fixed constructor set; receive variables today are **`Name`** slots in **`PInputs`**, not a general **`Proc::Var`**. For **structured receive patterns** (e.g. a pair of processes), variables must appear in **`Proc`** positions, not only in **`Name`**.
+
+**Options.**
+
+| Option | Approach | Pros | Cons |
+| ------ | -------- | ---- | ---- |
+| **A** | Add **`Proc`-level variable** (e.g. `PVar(x)` / `ProcVar`) | Single `Proc` AST; `unifies_proc` treats pattern-side var as wildcard (directional) | Parse, display, subst, and “no eval until ground” must include this form |
+| **B** | Only **Name-level** vars | Reuses `Name::Var` | Insufficient for structured **`Proc`** patterns |
+| **C** | Separate **`Pat`** category | Theoretically clean | Large migration and duplication vs `Proc` |
+
+**Recommendation.** **A** until a concrete conflict forces **C**: one process algebra with a distinguished variable form, aligned with directional `unifies_proc` and substitution.
+
+### Cross-cutting default for implementation
+
+Ship **keyword surface** `unifies(pat, val)` → **`Premise::Unification`**, **binary** `unifies_<cat>` in Ascent for the first milestone, **per-bind-site** **`Proc`** patterns on **`PInputs`**, and a **`Proc`** variable constructor—matching today’s parser, today’s COMM layout, and the staged “`σ` in Rust” plan, while leaving a clear path to three-place unification and multiset patterns when a hard requirement appears.
+
+## Macro and Runtime Changes
 
 | File                                    | Change                                                                                                         |
 | --------------------------------------- | -------------------------------------------------------------------------------------------------------------- |
@@ -61,14 +297,12 @@ High-level semantics:
 | `macros/src/gen/term_ops/`              | Add `apply_pattern` helper for binding extraction + multi-substitution.                                        |
 | `languages/src/rhocalc.rs`              | Add pattern-aware `PFor` form and COMM rewrite using unification premise.                                      |
 
-
 ## AST and Parsing
 
-Extend premise syntax with an explicit unification form. Exact concrete syntax can follow one of:
+**Preferred surface:** `unifies(pat, val)` parsed as **`Premise::Unification`** (see **§1** under [Design decisions and recommendations](#design-decisions-and-recommendations)). Alternatives still on the table for minor variants:
 
 - `pattern ~? received`
-- `unifies(pattern, received)`
-- `pattern unifies received`
+- `pattern unifies received` (infix keyword)
 
 Selection criteria:
 
@@ -150,9 +384,9 @@ This yields equational pattern matching while preserving relation-based guards.
 COMM rule shape:
 
 1. LHS identifies `(PFor n pattern body)` and `(POutput n received)` in parallel with `...rest`.
-2. Premise includes `unifies_proc(pattern, received)`.
+2. Premise includes `unifies_proc(pattern, received)` (or the parsed equivalent).
 3. RHS applies deterministic runtime helper:
-  - `apply_pattern(pattern, received, body)` -> substituted body.
+   - `apply_pattern(pattern, received, body)` → substituted body.
 4. Result term rebuilt into `PPar` with remainder.
 
 This keeps matching eligibility in fixpoint logic and avoids re-running expensive binder extraction unless the premise already succeeded.
@@ -164,9 +398,9 @@ This keeps matching eligibility in fixpoint logic and avoids re-running expensiv
 1. Structural walk over `(pattern, value)`.
 2. Binding collection map `{free_var -> matched_subterm}`.
 3. Conflict check (same free var bound multiple times):
-  - Either require alpha-equivalent/equal assignments.
-  - Or fail deterministically (rule does not fire).
-4. Capture-avoiding multi substitution into `body` using existing substitution utilities.
+   - Either require alpha-equivalent/equal assignments.
+   - Or fail deterministically (rule does not fire).
+4. Capture-avoiding multi substitution into `body` using existing substitution utilities (consistent with the `subst` relational spec).
 
 Recommended signature direction:
 
@@ -175,6 +409,159 @@ fn apply_pattern(pattern: &Proc, value: &Proc, body: &Proc) -> Option<Proc>
 ```
 
 Using `Option` (or `Result`) avoids panic paths and keeps COMM RHS generation straightforward.
+
+## Worked examples: surface language, parsing, internals, results
+
+Examples below mix **three layers** on purpose:
+
+1. **Object language** — what the programmer writes (Rholang-like or rhocalc concrete syntax).
+2. **`language!` judgement** — the rewrite rule the macro parses (names of pattern metasyntax variables such as `pat`, `recv`, `body`).
+3. **Implementation** — AST, generated Ascent, and Rust helpers.
+
+Some object-language constructs are **targets** of the [Design decisions](#design-decisions-and-recommendations) (per-channel **`Proc`** patterns, **`ProcVar`**); they are marked **(target)** where they are not yet the literal `rhocalc.rs` grammar.
+
+### Baseline: COMM today (no pattern unification premise)
+
+rhocalc already encodes multi-channel communication with **name** binders in **`PInputs`** and no `unifies` guard:
+
+```821:824:languages/src/rhocalc.rs
+        Comm . |- (PPar {(PInputs ns cont), *zip(ns,qs).*map(|n,q| (POutput n q)), ...rest})
+            ~> (PPar {(eval cont qs.*map(|q| (NQuote q))), ...rest});
+```
+
+Receive syntax binds **`Name`** parameters per channel, not arbitrary **`Proc`** patterns:
+
+```76:77:languages/src/rhocalc.rs
+        PInputs . ns:Vec(Name), ^[xs].p:[Name* -> Proc]
+        |- "(" *zip(ns,xs).*map(|n,x| n "?" x).*sep(",") ")" "." "{" p "}" : Proc ;
+```
+
+**Parse (rule row).** The macro parses the judgement’s `prop_context` as empty here; LHS/RHS are `Pattern` trees (`PPar`, `#zip`, `*map`, etc.).
+
+**Run.** Outputs `qs` are lined up with names `ns`; **`eval cont …`** desugars to **`MultiSubst`**: substitute quoted names into **`cont`**’s body. Matching of **payload structure** is not expressed as a premise—only arity/channel agreement via the LHS shape.
+
+---
+
+### Example 1 — Simple pattern variable vs literal value **(target)**
+
+**Object language (informal).** “Receive on `k` any process bound to pattern variable `x`; send `7` (as a process).”
+
+```text
+// Rholang-like
+for (x <- k) { P }  |  k!(@7)
+
+// rhocalc-like (target): one channel, pattern and payload as Proc
+// Concrete grammar TBD; illustrative shapes:
+//   receive:  (k ? x_pat).{ P }     with x_pat a ProcVar / pattern proc
+//   send:     k!(7)                 as existing output
+```
+
+**Rewrite rule (illustrative judgement).** Preferred premise shape from [§1 in Design decisions](#design-decisions-and-recommendations):
+
+```text
+CommPat . | unifies(pat, recv)
+    |- (PPar {(PInputs ns cont), (POutput n recv), ...rest})   // simplified: single output vs multi today
+    ~> (PPar {(apply_pattern pat recv body), ...rest});
+```
+
+In a full language, `pat` and `recv` are **metasyntax identifiers** bound by the LHS (e.g. `pat` extracted from the receive constructor, `recv` from the output). The design doc’s sketch used `PFor n pattern body`; rhocalc may keep **`PInputs`** and thread a **single** or **multi** pattern form—same idea.
+
+**Parsing.**
+
+1. **Propositional context:** `unifies(pat, recv)` is tokenized like a builtin call: keyword **`unifies`**, `(`, two identifiers, `)` → **`Premise::Unification { pattern: pat, value: recv }`** (not a user `RelationQuery`).
+2. **Judgement:** `|- … ~> …` parses LHS/RHS `Pattern` AST as today.
+
+**Internal processing.**
+
+| Stage | What happens |
+| ----- | ------------ |
+| Macro / `premise_to_condition` | Maps unification premise to a **condition** that codegen turns into an Ascent clause requiring **`unifies_proc(pat, recv)`** (or the category inferred for metavar `pat`). |
+| Generated Ascent | Rules from [Auto-Generated Structural Unification Rules](#auto-generated-structural-unification-rules) derive **`unifies_proc(pat, recv)`** when `pat` is a pattern-role variable and `recv` is e.g. `CastInt(7)`, or when both sides unify structurally. |
+| COMM clause | The rewrite rule’s generated clause lists **`unifies_proc(pat, recv)`** among conditions; if it cannot be derived, the COMM **does not fire**. |
+| RHS Rust | If the engine selects this rewrite, codegen emits **`apply_pattern(pat, recv, body)`** (or `Option` unwrap in a safe wrapper). |
+
+**Result.**
+
+- **Success:** `apply_pattern` builds `{ x ↦ CastInt(7) }` (names internalized per implementation), substitutes into **`body`**, and the parallel multiset loses the consumed receive/send pair—same high-level story as today’s **`Comm`**, but the guard is **structural** not “any name.”
+- **Failure:** If `recv` is not unifiable with `pat` (e.g. pattern expects a pair, value is an int), **`unifies_proc`** never holds → **no COMM** on that rule instance.
+
+---
+
+### Example 2 — Structured pattern **(target)**
+
+**Object idea.** Receive only if the payload matches **`(u, v)`**-shaped data (actual constructor names depend on rhocalc—tuple/list patterns are illustrative).
+
+```text
+Pattern pat ≅ ConsPair(PVar(a), PVar(b))     // illustrative
+Value recv ≅ ConsPair(CastInt(1), CastInt(2))
+Body   body uses a, b inside processes
+```
+
+**Premise.** `unifies(pat, recv)` recurses: unify heads, unify `PVar(a)` with `1`, `PVar(b)` with `2`.
+
+**`apply_pattern`.** Walk builds `σ = { a ↦ 1, b ↦ 2 }`; then multi-subst into `body`. If `body` binds `a` under **`PNew`**, substitution remains capture-avoiding via existing binder-aware **`subst`** machinery.
+
+**Result.** After COMM: continuation with **`a`/`b`** replaced; remainder of **`PPar`** unchanged.
+
+---
+
+### Example 3 — Repeated pattern variable (consistency)
+
+**Pattern.** `ConsPair(PVar(x), PVar(x))` (**(target)** syntax).
+
+| Value `recv` | `unifies_proc(pat, recv)` | `apply_pattern` / result |
+| ------------ | ------------------------- | -------------------------- |
+| `ConsPair(CastInt(1), CastInt(1))` | **yes** | `σ = { x ↦ 1 }`; body reduced |
+| `ConsPair(CastInt(1), CastInt(2))` | **no** | rule does not fire; **duplicate binding conflict** |
+
+Internally, the Ascent-side relation encodes agreement; the Rust walk **double-checks** conflicts and returns **`None`** if inconsistent—useful if codegen paths ever diverge.
+
+---
+
+### Example 4 — Congestion: match fails, process does not reduce on COMM
+
+**Configuration.** `pat` expects `CastInt`, `recv` is `CastStr("hi")`.
+
+**Ascent.** No fact **`unifies_proc(pat, recv)`** (no rule instance closes).
+
+**Outcome.** The top-level **`PPar`** is unchanged w.r.t. this COMM rule; other rules (congruence, other communications) may still apply.
+
+This is the practical payoff of **declarative** guards: failed match is **silent non-applicability**, not a runtime exception in the reduction engine.
+
+---
+
+### Example 5 — Multi-channel (today’s shape + future premise stack) **(target)**
+
+Today’s **`Comm`** uses **`#zip(ns, qs)`** to match many outputs. A future version can **keep that shape** and add **one unification premise per channel pair** (or a single premise over combined patterns, depending on encoding):
+
+```text
+// Illustrative: two outputs, two receives — details of pat₁/pat₂ binding TBD
+Comm2 . | unifies(pat1, recv1), unifies(pat2, recv2)
+    |- (PPar {(PInputs ns cont), *zip(ns, recvs).*map(|n,r| (POutput n r)), ...rest})
+    ~> (PPar {(apply_pattern_multi cont patterns recvs), ...rest});
+```
+
+**Parse.** Comma-separated premises → conjunction in `prop_context` (already the story in [01-26-syntax](01-26-syntax.md) for judgements).
+
+**Internal.** Ascent requires **both** `unifies_proc` facts; RHS applies substitutions consistent with **`cont`**’s multi-binder (today’s **`^[xs].p`** style, extended so each **`xᵢ`** aligns with a **`Proc`** pattern if needed).
+
+**Result.** Same concurrent intuition as current rhocalc **`Comm`**, with **pattern** discipline on each payload.
+
+---
+
+### Trace summary (mental checklist)
+
+```text
+Source text  →  language! parse  →  RewriteRule { premises, left, right }
+                      ↓
+               Premise::Unification → Condition → Ascent guard on COMM clause
+                      ↓
+Runtime term  →  Ascent fixpoint  →  unifies_* facts + rw_* / COMM conclusion
+                      ↓
+Selected COMM RHS  →  apply_pattern(pat, recv, body)  →  Option<Proc>
+                      ↓
+               Some(t) replaces redex; None ⇒ this RHS path not taken
+```
 
 ## Collection Pattern Matching (Hard Part)
 
@@ -220,6 +607,48 @@ To avoid accidental over-approximation:
 
 If true symmetric unification is later needed, it should be a separate relation with different rules and performance expectations.
 
+## Engineering constraints
+
+- **Priority:** correctness and a working demonstration first; heavy automata/static analysis later.
+- **Scope:** unification and patterns should scale toward integers, strings, algebraic data, and the full surface language—not only a minimal process fragment—without redesigning the Var/subst/unify split.
+- **Integration:** interpreter, Ascent reasoning, and future behavioral predicates should all be able to rely on the same substitution/unification story.
+
+## Build and run pipelines after pattern matching
+
+This section highlights **what changes operationally** once pattern matching and unification premises land—separating **compile-time (build)** from **runtime (reduction / execution)**. Wording applies to the **staged** plan: binary `unifies_<cat>` in Ascent plus Rust-side `apply_pattern` (or the existing `eval` / `MultiSubst` RHS path extended for patterns).
+
+### Build pipeline (`cargo build`, tests, CI)
+
+**Macro expansion (`mettail_macros` / `language!`).**
+
+- **Parsing:** the `language!` input gains new surface syntax (preferred: `unifies(pat, val)` in the propositional context; possible `Proc`/`PInputs` grammar changes for per-bind-site patterns). Expansion **fails fast** at compile time if premises or patterns are ill-formed—same class of errors as today for bad rewrite judgements.
+- **AST / lowering:** `Premise::Unification` and matching `Condition` variants feed `generate_condition_clauses` so COMM rules emit **extra Ascent guard literals** (calls into `unifies_<cat>(…)`), analogous to `rw_<cat>` for congruence.
+- **Generated logic:** `relations`-style emission declares **`unifies_<cat>`** for eligible categories; a **unification rule generator** (planned: `macros/src/logic/unification.rs`) adds many structurally recursive Ascent rules—**larger generated Datalog text** and slightly **longer macro expansion time** for big languages (`Proc` with many constructors). Phase 3 (multiset / `PPar`) increases rule bulk further.
+- **Generated Rust:** rhocalc’s generated term algebra picks up **`Proc`-level variables** and any new constructors; **`apply_pattern`** (or extended term ops) appears under `macros/src/gen/term_ops/` and is linked from generated `impl` blocks as needed.
+- **Downstream crates:** touching `macros` typically forces **rebuild of `languages`**, anything that `include!`s generated Ascent, and tests that diff codegen—**no new mandatory manual step** beyond a normal workspace `cargo build` / `cargo test`.
+
+**Net effect on build.** Incremental **compile time and artifact size** grow modestly with generated rule count; worst-case jumps appear when collection unification lands. CI should add or extend **macro-level tests** (premise parse → expected Ascent fragments) and **integration tests** (COMM match / no-match).
+
+### Run pipeline (rewrite engine, reductions, tooling)
+
+**Ascent fixpoint (when rewrites run inside the logical engine).**
+
+- The engine still runs **stratified** rounds; **new relations** `unifies_<cat>` participate in the **same** overall schedule as other generated relations (`eq_*`, `rw_*`, …). A COMM rule with a unification premise **does not fire** until matching `unifies_*` facts are derived—so some reductions become **guard-order dependent** in the same way congruence already depends on `rw_*`.
+- **Work per step:** each candidate COMM may trigger **extra joins** on `unifies_proc( pattern, received )` (and later, heavier multiset search). Cost is **pattern-size- and term-size-dependent**; Phase 1 structural rules aim to stay predictable.
+
+**Rust runtime (term construction after a rule matches).**
+
+- When the COMM RHS runs, **bindings are not read back from Datalog tuples** in the staged design: **`apply_pattern`** (or `MultiSubst` extended for patterns) **re-walks** `(pattern, value)` and then substitutes into the continuation. That adds **deterministic CPU** proportional to pattern + value size, in exchange for a simpler relation arity and reuse of existing substitution infrastructure.
+
+**User-visible behavior.**
+
+- **Fewer spurious COMM steps:** sends that do not match a receive **pattern** do not reduce (soundness vs today’s name-only receive in some embeddings).
+- **REPL / drivers** unchanged in **invocation** (`cargo run` on `repl`, same APIs); behavior changes only where **reduction sequences** differ.
+
+**What stays the same.**
+
+- Workspace layout, **Ascent engine crate** boundary (per [Non-goals](#non-goals)), and the high-level story “macro generates logic + Rust terms; engine runs fixpoint” are unchanged—pattern matching **extends** the pipelines rather than replacing them.
+
 ## Rollout Plan
 
 ### Phase 1: Minimal structural unification
@@ -250,36 +679,55 @@ If true symmetric unification is later needed, it should be a separate relation 
 ## Testing Strategy
 
 1. **Codegen tests (macro level):**
-  - Premise parse and AST mapping for unification syntax.
-  - Generated Ascent includes `unifies_<cat>` clauses.
+   - Premise parse and AST mapping for unification syntax.
+   - Generated Ascent includes `unifies_<cat>` clauses.
 2. **Relation semantics tests:**
-  - Ground constructor success/failure.
-  - Recursive constructor descent.
-  - Pattern free-var wildcard behavior and side restrictions.
+   - Ground constructor success/failure.
+   - Recursive constructor descent.
+   - Pattern free-var wildcard behavior and side restrictions.
 3. **COMM integration tests (language level):**
-  - Message matches pattern -> rewrite fires with expected substitution.
-  - Non-matching message -> rewrite blocked.
-  - Repeated variable in pattern requires consistent binding.
+   - Message matches pattern → rewrite fires with expected substitution.
+   - Non-matching message → rewrite blocked.
+   - Repeated variable in pattern requires consistent binding.
 4. **Collection tests:**
-  - Deterministic small bag matches.
-  - Rest binding correctness.
-  - Ambiguous branches converge to equivalent outcomes (or expected multiplicity semantics).
+   - Deterministic small bag matches.
+   - Rest binding correctness.
+   - Ambiguous branches converge to equivalent outcomes (or expected multiplicity semantics).
 5. **Performance checks:**
-  - Small/medium pattern sizes benchmarked to detect regressions.
+   - Small/medium pattern sizes benchmarked to detect regressions.
 
 ## Non-Goals
 
 - Changing Ascent engine internals.
-- Replacing existing substitution or binder infrastructure.
+- Replacing existing substitution or binder infrastructure wholesale without a migration story.
 - General-purpose higher-order unification beyond the pattern-matching use case.
 
 ## Open Questions
 
-1. **Syntax choice:** which unification-premise syntax best fits existing language grammar?
-2. **Directionality encoding:** separate `matches(pattern, value)` relation vs directional constraints on `unifies`.
+Resolved directions for syntax, Datalog arity, first COMM scope, and `Proc` variables are in [Design decisions and recommendations](#design-decisions-and-recommendations); remaining items:
+
+1. **Sign-off:** adopt `unifies(pat, val)` + `Premise::Unification` as the locked surface syntax (vs minor variants like explicit `unifies_proc`).
+2. **Directionality encoding:** separate `matches(pattern, value)` relation vs directional constraints on `unifies` if we ever need symmetric unification for a different rule class.
 3. **Conflict policy:** when a variable appears multiple times in a pattern, require strict structural equality or eq-closure equality?
 4. **Collection semantics:** should multiple valid multiset matches produce multiple rewrites or deterministic single rewrite selection?
 5. **Eq integration timing:** ship structural matching first, then add equational closure, or ship together behind a feature gate?
+6. **Surfacing `σ`:** when (if ever) must binding environments appear as explicit Datalog tuples for behavioral typing rules—trigger to move from binary `unifies_<cat>` to option B/C in §2 above?
+
+## Conceptual summary
+
+Pattern-based COMM in a logical embedding of Rholang needs **explicit variable syntax**, a **capture-avoiding substitution** primitive (spec’d relationally as `subst`), and **unification premises** that relate receive patterns to sent values before a reduction fires. Bindings `σ` justify applying substitution to the continuation. Explicit variables are chosen over purely implicit lambda binding so patterns can bind dynamically during matching and the theory can grow toward behavioral predicates and Ascent-side reasoning without rewriting the core term algebra. The implementation can stage eligibility as binary `unifies_<cat>` in Ascent while reconstructing `σ` in `apply_pattern` on the COMM RHS, unless a later design lifts full `unify(pattern, value, env)` into relations.
+
+## Minimal mental model
+
+```text
+match(pattern, value)  — as unification premises / unifies_*
+        ↓
+produce bindings σ       — via apply_pattern walk (staged) or explicit env relation (future)
+        ↓
+apply subst(continuation, σ)
+        ↓
+COMM reduction fires
+```
 
 ## Expected Benefits
 
@@ -287,4 +735,4 @@ If true symmetric unification is later needed, it should be a separate relation 
 - Keeps rewrite guards declarative and compositional.
 - Aligns with current macro architecture (parallel to congruence generation).
 - Enables expressive COMM/pattern semantics without engine-level changes.
-
+- Grounds future **behavioral types** in the same pattern/unification/substitution core.

--- a/docs/design/exploring/unification-premises-for-pattern-comm.md
+++ b/docs/design/exploring/unification-premises-for-pattern-comm.md
@@ -1,0 +1,290 @@
+# Unification Premises for Pattern-Based COMM
+
+## Goal
+
+Enable relation-based pattern matching in rewrite premises so COMM-style rules can be guarded by unification:
+
+```text
+Comm . | pattern unifies received
+     |- (PPar {(PFor n pattern body), (POutput n received), ...rest})
+     ~> (PPar {(apply_pattern pattern received body), ...rest})
+```
+
+The intent is to keep "does this match?" inside Ascent/Datalog fixpoint computation, while keeping binding extraction and substitution in deterministic Rust runtime code.
+
+## Current Baseline
+
+Today, premise relations already participate in fixpoint scheduling via generated relation lookups. In particular:
+
+- Congruence premise `S ~> T` is lowered to a relation query (`rw_<cat>(S, T)`).
+- Premise lowering is handled through `Premise -> Condition` and `generate_condition_clauses` in `macros/src/logic/rules.rs`.
+- Ascent evaluates premise relations to fixpoint before dependent rewrites fire.
+
+This is exactly the mechanism needed for unification premises: add `unifies_<cat>(pattern, value)` and reuse the same condition-generation plumbing.
+
+## Design Overview
+
+The feature is split into two responsibilities:
+
+1. **Datalog relation (`unifies_`*)** answers whether a pattern unifies with a value.
+2. **Runtime function (`apply_pattern`)** computes bindings and performs substitution once a rule fires.
+
+This mirrors existing architecture where relations express logical preconditions and Rust handles deterministic term construction/evaluation.
+
+## Proposed Semantics
+
+For each category `Cat` (for example `Proc`, `Name`), introduce:
+
+```text
+relation unifies_cat(Cat, Cat);
+```
+
+Read as: "`lhs` unifies with `rhs`".
+
+High-level semantics:
+
+- Constructor-to-constructor unification succeeds when labels match and all corresponding child positions unify.
+- Pattern free variables in designated "pattern position" unify with any value at that position.
+- Collection constructors unify via multiset matching (see dedicated section).
+- Optional equational closure may be layered so unification sees equation-equivalent values.
+
+## Macro and Runtime Changes
+
+
+| File                                    | Change                                                                                                         |
+| --------------------------------------- | -------------------------------------------------------------------------------------------------------------- |
+| `macros/src/ast/language.rs`            | Add `Premise::Unification { pattern, value }` (or similarly named fields).                                     |
+| `macros/src/ast/grammar.rs`             | Add/extend `TermParam` metadata to mark pattern-binder positions (if needed by codegen).                       |
+| `macros/src/logic/relations.rs`         | Emit `unifies_<cat>` declarations for eligible categories.                                                     |
+| `macros/src/logic/unification.rs` (new) | Auto-generate structural unification rules per constructor (parallel to congruence generation style).          |
+| `macros/src/logic/rules.rs`             | Lower `Premise::Unification` to `Condition::EnvQuery`-like relation clause generation (new condition variant). |
+| `macros/src/gen/term_ops/`              | Add `apply_pattern` helper for binding extraction + multi-substitution.                                        |
+| `languages/src/rhocalc.rs`              | Add pattern-aware `PFor` form and COMM rewrite using unification premise.                                      |
+
+
+## AST and Parsing
+
+Extend premise syntax with an explicit unification form. Exact concrete syntax can follow one of:
+
+- `pattern ~? received`
+- `unifies(pattern, received)`
+- `pattern unifies received`
+
+Selection criteria:
+
+- Must be unambiguous with existing `~>` and `=` judgements.
+- Must parse to two identifiers/terms that are already bound in the rule context.
+- Should preserve existing parser constraints for premise atoms and conjunctions.
+
+AST addition (illustrative):
+
+```rust
+pub enum Premise {
+    Freshness(FreshnessCondition),
+    Congruence { source: Ident, target: Ident },
+    RelationQuery { relation: Ident, args: Vec<Ident> },
+    ForAll { collection: Ident, param: Ident, body: Box<Premise> },
+    Unification { pattern: Ident, value: Ident },
+}
+```
+
+Internal `Condition` should gain a matching variant so `generate_condition_clauses` can emit `unifies_<cat>(pattern, value)`.
+
+## Relation Declaration and Generation
+
+In logic relation declaration generation (`macros/src/logic/relations.rs`), emit:
+
+- `relation unifies_proc(Proc, Proc);`
+- `relation unifies_name(Name, Name);`
+- etc., for categories where matching is meaningful.
+
+Generation policy should mirror existing category filters used in congruence/equations codegen to keep behavior deterministic and compile-time bounded.
+
+## Auto-Generated Structural Unification Rules
+
+New module `macros/src/logic/unification.rs` generates Ascent rules for each constructor shape.
+
+### 1) Ground constructor rule
+
+For nullary constructors, emit direct self-match rules.
+
+### 2) Recursive constructor rule
+
+For constructor `C` with child fields `(f1, ..., fn)`:
+
+```text
+unifies_cat(a, b) <--
+  cat(a), cat(b),
+  if let Cat::C(...f1a..., ...fna...) = a,
+  if let Cat::C(...f1b..., ...fnb...) = b,
+  unifies_child1(f1a, f1b),
+  ...
+  unifies_childN(fna, fnb);
+```
+
+Where each `unifies_childK` dispatches to the corresponding category relation (`unifies_proc`, `unifies_name`, etc.).
+
+### 3) Pattern variable wildcard rule
+
+For designated pattern-variable positions, emit rules that allow wildcard matching:
+
+```text
+unifies_cat(a, b) <-- cat(a), cat(b), if a.is_free_var();
+```
+
+Important: this must only apply in pattern role, not symmetrically in all contexts, otherwise relation meaning degrades to near-universal matching for terms containing free vars.
+
+### 4) Optional equational closure
+
+If equational matching is desired, add closure rules such as:
+
+```text
+unifies_cat(a, c) <-- eq_cat(a, b), unifies_cat(b, c);
+unifies_cat(a, c) <-- unifies_cat(a, b), eq_cat(b, c);
+```
+
+This yields equational pattern matching while preserving relation-based guards.
+
+## COMM Integration
+
+COMM rule shape:
+
+1. LHS identifies `(PFor n pattern body)` and `(POutput n received)` in parallel with `...rest`.
+2. Premise includes `unifies_proc(pattern, received)`.
+3. RHS applies deterministic runtime helper:
+  - `apply_pattern(pattern, received, body)` -> substituted body.
+4. Result term rebuilt into `PPar` with remainder.
+
+This keeps matching eligibility in fixpoint logic and avoids re-running expensive binder extraction unless the premise already succeeded.
+
+## `apply_pattern` Runtime Contract
+
+`apply_pattern(pattern, value, body)` performs:
+
+1. Structural walk over `(pattern, value)`.
+2. Binding collection map `{free_var -> matched_subterm}`.
+3. Conflict check (same free var bound multiple times):
+  - Either require alpha-equivalent/equal assignments.
+  - Or fail deterministically (rule does not fire).
+4. Capture-avoiding multi substitution into `body` using existing substitution utilities.
+
+Recommended signature direction:
+
+```rust
+fn apply_pattern(pattern: &Proc, value: &Proc, body: &Proc) -> Option<Proc>
+```
+
+Using `Option` (or `Result`) avoids panic paths and keeps COMM RHS generation straightforward.
+
+## Collection Pattern Matching (Hard Part)
+
+Structural constructor matching is straightforward; multiset patterns are the complexity center.
+
+Case: `PPar` represented as `HashBag<Proc>` with pattern elements `P1, P2, ..., Pk, ...rest`.
+
+Required behavior:
+
+- Each `Pi` must match a distinct element in value bag.
+- Remaining elements bind to `...rest` when present.
+- Bindings from each `Pi` merge consistently.
+
+### Search strategy
+
+Backtracking search over pattern elements:
+
+1. Choose next unmatched pattern element.
+2. Iterate candidate value elements in remaining bag.
+3. Keep candidates satisfying `unifies_proc(Pi, candidate)`.
+4. Remove chosen candidate from remaining bag and recurse.
+5. Merge bindings; reject branch on conflict.
+
+Ascent can encode candidate generation through `for`-style clauses, but consumed-element tracking must be explicit (for example via iterative bag removal values in intermediate bindings).
+
+### Complexity
+
+General multiset matching is NP-hard. Practical mitigation:
+
+- Patterns in language rules are usually small.
+- Heuristics can reduce branching:
+  - Match most selective pattern elements first (fewest candidates).
+  - Prefer ground constructors before free-variable patterns.
+  - Early fail on arity/size constraints.
+
+## Soundness and Directionality Notes
+
+To avoid accidental over-approximation:
+
+- Treat unification premise as **directional pattern matching** (pattern -> value), even if relation is syntactically binary.
+- Restrict wildcard/free-var rules to pattern side only.
+- Ensure relation is not used as a generic equivalence relation unless explicitly intended.
+
+If true symmetric unification is later needed, it should be a separate relation with different rules and performance expectations.
+
+## Rollout Plan
+
+### Phase 1: Minimal structural unification
+
+- Add AST + parsing + relation declaration plumbing.
+- Generate unification rules for non-collection constructors.
+- Add premise lowering in rule codegen.
+- Add small unit tests for constructor and free-var behavior.
+
+### Phase 2: COMM + runtime bindings
+
+- Add `apply_pattern` runtime helper.
+- Introduce/update `PFor` pattern-binder form in rhocalc.
+- Implement COMM rewrite using unification premise and `apply_pattern`.
+- Add end-to-end tests for successful/failed communication matches.
+
+### Phase 3: Collection unification
+
+- Implement `PPar`/bag matching with consumed-element tracking.
+- Add ambiguity/conflict tests and backtracking coverage.
+- Add stress tests for branching behavior and guardrails.
+
+### Phase 4: Equational composition (optional)
+
+- Add eq-closure integration with `unifies_`*.
+- Verify compatibility with existing `eq_*` and `rw_*` closure behavior.
+
+## Testing Strategy
+
+1. **Codegen tests (macro level):**
+  - Premise parse and AST mapping for unification syntax.
+  - Generated Ascent includes `unifies_<cat>` clauses.
+2. **Relation semantics tests:**
+  - Ground constructor success/failure.
+  - Recursive constructor descent.
+  - Pattern free-var wildcard behavior and side restrictions.
+3. **COMM integration tests (language level):**
+  - Message matches pattern -> rewrite fires with expected substitution.
+  - Non-matching message -> rewrite blocked.
+  - Repeated variable in pattern requires consistent binding.
+4. **Collection tests:**
+  - Deterministic small bag matches.
+  - Rest binding correctness.
+  - Ambiguous branches converge to equivalent outcomes (or expected multiplicity semantics).
+5. **Performance checks:**
+  - Small/medium pattern sizes benchmarked to detect regressions.
+
+## Non-Goals
+
+- Changing Ascent engine internals.
+- Replacing existing substitution or binder infrastructure.
+- General-purpose higher-order unification beyond the pattern-matching use case.
+
+## Open Questions
+
+1. **Syntax choice:** which unification-premise syntax best fits existing language grammar?
+2. **Directionality encoding:** separate `matches(pattern, value)` relation vs directional constraints on `unifies`.
+3. **Conflict policy:** when a variable appears multiple times in a pattern, require strict structural equality or eq-closure equality?
+4. **Collection semantics:** should multiple valid multiset matches produce multiple rewrites or deterministic single rewrite selection?
+5. **Eq integration timing:** ship structural matching first, then add equational closure, or ship together behind a feature gate?
+
+## Expected Benefits
+
+- Reuses existing relation-premise fixpoint machinery cleanly.
+- Keeps rewrite guards declarative and compositional.
+- Aligns with current macro architecture (parallel to congruence generation).
+- Enables expressive COMM/pattern semantics without engine-level changes.
+

--- a/docs/design/exploring/unification-premises-for-pattern-comm.md
+++ b/docs/design/exploring/unification-premises-for-pattern-comm.md
@@ -38,7 +38,7 @@ Pattern matching touches **two** syntactic worlds:
 
 - **End users** (REPL, tests, embeddings) write **object-language** **source** that parses as **`Proc`** (and friends)—for example the strings in [`repl/src/examples/rhocalc.rs`](../../../repl/src/examples/rhocalc.rs). They **do not** type judgement rules or **`unifies(…)`** at the prompt. They only write processes; COMM with unification is triggered **implicitly** when the engine applies the **`Comm`** rewrite produced from `rewrites { … }`.
 
-**Implication:** unification **premises** are **author-facing**; **pattern syntax** (new **`Proc`** constructors and evolved receive forms) is **user-facing**. You cannot get meaningful pattern COMM in the REPL without extending **`terms { … }`** (and usually **`PInputs`**) so patterns and payloads are **shared `Proc`** ASTs that **`unifies_proc`** can relate. See [Concrete syntax proposal](#concrete-syntax-proposal-for-this-document) below.
+**Implication:** unification **premises** are **author-facing**; **pattern syntax** (new **`Proc`** constructors and evolved receive forms) is **user-facing**. You cannot get meaningful pattern COMM in the REPL without extending **`terms { … }`** (and usually **`PInputs`**) so patterns and payloads are **shared `Proc`** ASTs that **`unifies_proc`** can relate. See [Concrete syntax proposal](#concrete-syntax-proposal) below.
 
 ## Concrete syntax proposal
 
@@ -69,66 +69,7 @@ Patterns are **`Proc`** values built from **constructors**. At minimum:
 
 REPL examples in this repo historically use **`for(a -> x){ … }`** style strings (see [repl examples](../../../repl/src/examples/rhocalc.rs)). **Proposal:** keep that sugar; extend the grammar so **the binding after `->`** can be a **`Proc` pattern** (e.g. **`for(c -> $x){ … }`**, **`for(c -> pair($u, $v)){ … }`**), lowering to the same **`PInputs`**-like constructor as concrete **`( c ? … ).{ … }`** form.
 
----
-
-### Example — `language!` fragments (author)
-
-**New process constructors (illustrative):**
-
-```text
-PPatVar . x:Name |- "$" x : Proc;
-
-PPair . u:Proc, v:Proc |- "pair" "(" u "," v ")" : Proc;
-```
-
-**Receive constructor (target shape — replaces single `Name` per arm with `Proc` pattern):**
-
-```text
-PInputs . ns:Vec(Name), pats:Vec(Proc), ^[xs].p:[Name* -> Proc]
-    |- "(" *zip(ns, pats).*map(|n, pat| n "?" pat).*sep(",") ")" "." "{" p "}" : Proc ;
-```
-
-**COMM rewrite (single-channel sketch; real rhocalc keeps multiset `...rest`):**
-
-```text
-CommPat . | unifies(pat, q)
-    |- (PPar {(PInputs ns pats cont), *zip(ns, qs).*map(|n, q| (POutput n q)), ...rest})
-    ~> (PPar {(apply_pattern_chain cont pats qs), ...rest});
-```
-
-Here **`apply_pattern_chain`** stands for the generated RHS that walks **aligned `pats`** and **`qs`** (and substitutes into **`cont`**)—either one **n-ary** helper or nested **`apply_pattern`** / **`eval`**; naming is illustrative.
-
----
-
-### Example — REPL / user programs
-
-Assuming **`$x`** and **`pair`** exist as above, and integer literals are processes (existing casts):
-
-**1) Pattern variable vs literal payload**
-
-```text
-{ c!(7) | for(c -> $x){ int($x, 64) } }
-```
-
-**Intent:** send **`7`** as **`Proc`**; receive matches **`$x`**; continuation runs **`int($x, 64)`** with **`$x`** replaced by the matched value (requires **`int`**’s first argument to accept that **`Proc`** shape—consistent with rhocalc’s numeric **`Proc`** helpers).
-
-**2) Structured pattern**
-
-```text
-{ c!(pair(1, 2)) | for(c -> pair($u, $v)){ int($u, 64) } }
-```
-
-**Intent:** COMM only if payload is **`pair`** of two values; bind **`u`**, **`v`**; run body with those bindings.
-
-**3) No match (stuck w.r.t. this COMM)**
-
-```text
-{ c!("hi") | for(c -> $x){ int($x, 64) } }
-```
-
-**Intent:** if **`$x`** cannot unify with string payload under **`unifies_proc`**, this **`CommPat`** instance does not fire.
-
-Users still **select Rho calculus** in the REPL and paste one **`{ … }`** process; stepping behavior changes only through the **new** **`Comm`** rule and **pattern** grammar.
+End-to-end walkthroughs (**`rhocalc.rs` → user program → channel data → output**) are in [Worked examples (four-part layout)](#worked-examples-four-part-layout).
 
 ## Key design decision: explicit variables instead of implicit binding
 
@@ -395,7 +336,7 @@ Ship **keyword surface** `unifies(pat, val)` → **`Premise::Unification`**, **b
 | `macros/src/logic/unification.rs` (new) | Auto-generate structural unification rules per constructor (parallel to congruence generation style).          |
 | `macros/src/logic/rules.rs`             | Lower `Premise::Unification` to `Condition::EnvQuery`-like relation clause generation (new condition variant). |
 | `macros/src/gen/term_ops/`              | Add `apply_pattern` helper for binding extraction + multi-substitution.                                        |
-| `languages/src/rhocalc.rs`              | Add **`PPatVar`** / **`$x`**, evolve **`PInputs`** for **`Proc`** patterns, optional **`pair`** (or chosen product), and **`CommPat`** with **`unifies`** + **`apply_pattern`** (see [Concrete syntax proposal](#concrete-syntax-proposal-for-this-document)). |
+| `languages/src/rhocalc.rs`              | Add **`PPatVar`** / **`$x`**, evolve **`PInputs`** for **`Proc`** patterns, optional **`pair`** (or chosen product), and **`CommPat`** with **`unifies`** + **`apply_pattern`** (see [Concrete syntax proposal](#concrete-syntax-proposal)). |
 
 ## AST and Parsing
 
@@ -510,19 +451,20 @@ fn apply_pattern(pattern: &Proc, value: &Proc, body: &Proc) -> Option<Proc>
 
 Using `Option` (or `Result`) avoids panic paths and keeps COMM RHS generation straightforward.
 
-## Worked examples: surface language, parsing, internals, results
+## Worked examples (four-part layout)
 
-Examples below mix **three layers** on purpose:
+Each scenario uses the same structure:
 
-1. **Object language** — what the programmer writes (Rholang-like or rhocalc concrete syntax).
-2. **`language!` judgement** — the rewrite rule the macro parses (names of pattern metasyntax variables such as `pat`, `recv`, `body`).
-3. **Implementation** — AST, generated Ascent, and Rust helpers.
+1. **Changes in [`rhocalc.rs`](../../../languages/src/rhocalc.rs)** — what the language author adds or edits inside `language!` (**proposal** until merged).
+2. **User’s program** — REPL / PraTT-style source the end user writes.
+3. **Data on the channel** — **message** (`Proc` crossing the channel) vs **pattern** on the receive arm; **`unifies_proc`** reasons about this pair (directional: pattern first, message second).
+4. **Output** — **residual process** after COMM (or why nothing reduced), with a short explanation.
 
-Some object-language constructs are **targets** of the [Design decisions](#design-decisions-and-recommendations) (per-channel **`Proc`** patterns, **`ProcVar`**); they are marked **(target)** where they are not yet the literal `rhocalc.rs` grammar.
+Parsing / Ascent plumbing (**`Premise::Unification`**, **`generate_condition_clauses`**, etc.) is unchanged in spirit from [Design decisions §1](#1-surface-syntax-for-the-unification-premise) and [Auto-Generated Structural Unification Rules](#auto-generated-structural-unification-rules).
 
-### Baseline: COMM today (no pattern unification premise)
+### Baseline — today’s COMM (name binders only)
 
-rhocalc already encodes multi-channel communication with **name** binders in **`PInputs`** and no `unifies` guard:
+**1. Changes in `rhocalc.rs`** — already in tree; no **`unifies`** premise. Multi-channel **COMM** uses:
 
 ```821:824:languages/src/rhocalc.rs
         Comm . |- (PPar {(PInputs ns cont), *zip(ns,qs).*map(|n,q| (POutput n q)), ...rest})
@@ -536,114 +478,143 @@ Receive syntax binds **`Name`** parameters per channel, not arbitrary **`Proc`**
         |- "(" *zip(ns,xs).*map(|n,x| n "?" x).*sep(",") ")" "." "{" p "}" : Proc ;
 ```
 
-**Parse (rule row).** The macro parses the judgement’s `prop_context` as empty here; LHS/RHS are `Pattern` trees (`PPar`, `#zip`, `*map`, etc.).
-
-**Run.** Outputs `qs` are lined up with names `ns`; **`eval cont …`** desugars to **`MultiSubst`**: substitute quoted names into **`cont`**’s body. Matching of **payload structure** is not expressed as a premise—only arity/channel agreement via the LHS shape.
-
----
-
-### Example 1 — Simple pattern variable vs literal value **(target)**
-
-**Object language (informal).** “Receive on `k` any process bound to pattern variable `x`; send `7` (as a process).”
+**2. User’s program**
 
 ```text
-// Rholang-like
-for (x <- k) { P }  |  k!(@7)
-
-// rhocalc / REPL (proposal — see § Concrete syntax proposal):
-//   { k!(7) | for(k -> $x){ … body using $x … } }
+{ a!(0) | for(a -> x){ *(x) } }
 ```
 
-**Rewrite rule (illustrative judgement).** Preferred premise shape from [§1 in Design decisions](#design-decisions-and-recommendations):
+**3. Data on the channel**  
+On **`a`**, the **message** is the process **`0`**. The receive arm binds **name** **`x`** (**`Name`**) per channel, not a **`Proc`** pattern. There is **no** **`unifies_proc`** check on payload shape—only alignment of **`ns`** with **`qs`** and **`eval cont qs.*map(|q| (NQuote q))`** into **`cont`**.
+
+**4. Output and explanation**  
+The matching send/receive pair is removed from **`PPar`**; **`cont`** is filled via **`MultiSubst`**. This **baseline** is what **`CommPat`** extends with **structural** guards.
+
+---
+
+### Scenario A — pattern variable vs literal **(proposal)**
+
+**1. Changes in `rhocalc.rs`**
 
 ```text
-CommPat . | unifies(pat, recv)
-    |- (PPar {(PInputs ns cont), (POutput n recv), ...rest})   // simplified: single output vs multi today
-    ~> (PPar {(apply_pattern pat recv body), ...rest});
+PPatVar . x:Name |- "$" x : Proc;
+
+PInputs . ns:Vec(Name), pats:Vec(Proc), ^[xs].p:[Name* -> Proc]
+    |- "(" *zip(ns, pats).*map(|n, pat| n "?" pat).*sep(",") ")" "." "{" p "}" : Proc ;
+
+CommPat . | unifies(pat, q)
+    |- (PPar {(PInputs ns pats cont), *zip(ns, qs).*map(|n, q| (POutput n q)), ...rest})
+    ~> (PPar {(apply_pattern_chain cont pats qs), ...rest});
 ```
 
-In a full language, `pat` and `recv` are **metasyntax identifiers** bound by the LHS (e.g. `pat` extracted from the receive constructor, `recv` from the output). The design doc’s sketch used `PFor n pattern body`; rhocalc may keep **`PInputs`** and thread a **single** or **multi** pattern form—same idea.
-
-**Parsing.**
-
-1. **Propositional context:** `unifies(pat, recv)` is tokenized like a builtin call: keyword **`unifies`**, `(`, two identifiers, `)` → **`Premise::Unification { pattern: pat, value: recv }`** (not a user `RelationQuery`).
-2. **Judgement:** `|- … ~> …` parses LHS/RHS `Pattern` AST as today.
-
-**Internal processing.**
-
-| Stage | What happens |
-| ----- | ------------ |
-| Macro / `premise_to_condition` | Maps unification premise to a **condition** that codegen turns into an Ascent clause requiring **`unifies_proc(pat, recv)`** (or the category inferred for metavar `pat`). |
-| Generated Ascent | Rules from [Auto-Generated Structural Unification Rules](#auto-generated-structural-unification-rules) derive **`unifies_proc(pat, recv)`** when `pat` is a pattern-role variable and `recv` is e.g. `CastInt(7)`, or when both sides unify structurally. |
-| COMM clause | The rewrite rule’s generated clause lists **`unifies_proc(pat, recv)`** among conditions; if it cannot be derived, the COMM **does not fire**. |
-| RHS Rust | If the engine selects this rewrite, codegen emits **`apply_pattern(pat, recv, body)`** (or `Option` unwrap in a safe wrapper). |
-
-**Result.**
-
-- **Success:** `apply_pattern` builds `{ x ↦ CastInt(7) }` (names internalized per implementation), substitutes into **`body`**, and the parallel multiset loses the consumed receive/send pair—same high-level story as today’s **`Comm`**, but the guard is **structural** not “any name.”
-- **Failure:** If `recv` is not unifiable with `pat` (e.g. pattern expects a pair, value is an int), **`unifies_proc`** never holds → **no COMM** on that rule instance.
-
----
-
-### Example 2 — Structured pattern **(target)**
-
-**Object idea.** Receive only if the payload matches **`(u, v)`**-shaped data (actual constructor names depend on rhocalc—tuple/list patterns are illustrative).
+**2. User’s program**
 
 ```text
-Pattern pat ≅ ConsPair(PVar(a), PVar(b))     // illustrative
-Value recv ≅ ConsPair(CastInt(1), CastInt(2))
-Body   body uses a, b inside processes
+{ c!(7) | for(c -> $x){ int($x, 64) } }
 ```
 
-**Premise.** `unifies(pat, recv)` recurses: unify heads, unify `PVar(a)` with `1`, `PVar(b)` with `2`.
+**3. Data on the channel**  
+**Message:** **`7`** as **`Proc`**. **Pattern:** **`$x`** (**`PPatVar`**). Check **`unifies_proc(PPatVar(x), 7)`**.
 
-**`apply_pattern`.** Walk builds `σ = { a ↦ 1, b ↦ 2 }`; then multi-subst into `body`. If `body` binds `a` under **`PNew`**, substitution remains capture-avoiding via existing binder-aware **`subst`** machinery.
-
-**Result.** After COMM: continuation with **`a`/`b`** replaced; remainder of **`PPar`** unchanged.
-
----
-
-### Example 3 — Repeated pattern variable (consistency)
-
-**Pattern.** `ConsPair(PVar(x), PVar(x))` (**(target)** syntax).
-
-| Value `recv` | `unifies_proc(pat, recv)` | `apply_pattern` / result |
-| ------------ | ------------------------- | -------------------------- |
-| `ConsPair(CastInt(1), CastInt(1))` | **yes** | `σ = { x ↦ 1 }`; body reduced |
-| `ConsPair(CastInt(1), CastInt(2))` | **no** | rule does not fire; **duplicate binding conflict** |
-
-Internally, the Ascent-side relation encodes agreement; the Rust walk **double-checks** conflicts and returns **`None`** if inconsistent—useful if codegen paths ever diverge.
+**4. Output and explanation**  
+Remaining process includes **`int(7, 64)`** after send/receive on **`c`** are consumed. Ascent must derive **`unifies_proc`** before this COMM instance closes.
 
 ---
 
-### Example 4 — Congestion: match fails, process does not reduce on COMM
+### Scenario B — structured **`pair`** **(proposal)**
 
-**Configuration.** `pat` expects `CastInt`, `recv` is `CastStr("hi")`.
-
-**Ascent.** No fact **`unifies_proc(pat, recv)`** (no rule instance closes).
-
-**Outcome.** The top-level **`PPar`** is unchanged w.r.t. this COMM rule; other rules (congruence, other communications) may still apply.
-
-This is the practical payoff of **declarative** guards: failed match is **silent non-applicability**, not a runtime exception in the reduction engine.
-
----
-
-### Example 5 — Multi-channel (today’s shape + future premise stack) **(target)**
-
-Today’s **`Comm`** uses **`#zip(ns, qs)`** to match many outputs. A future version can **keep that shape** and add **one unification premise per channel pair** (or a single premise over combined patterns, depending on encoding):
+**1. Changes in `rhocalc.rs`**  
+Scenario A, plus:
 
 ```text
-// Illustrative: two outputs, two receives — details of pat₁/pat₂ binding TBD
-Comm2 . | unifies(pat1, recv1), unifies(pat2, recv2)
-    |- (PPar {(PInputs ns cont), *zip(ns, recvs).*map(|n,r| (POutput n r)), ...rest})
-    ~> (PPar {(apply_pattern_multi cont patterns recvs), ...rest});
+PPair . u:Proc, v:Proc |- "pair" "(" u "," v ")" : Proc;
 ```
 
-**Parse.** Comma-separated premises → conjunction in `prop_context` (already the story in [01-26-syntax](01-26-syntax.md) for judgements).
+**2. User’s program**
 
-**Internal.** Ascent requires **both** `unifies_proc` facts; RHS applies substitutions consistent with **`cont`**’s multi-binder (today’s **`^[xs].p`** style, extended so each **`xᵢ`** aligns with a **`Proc`** pattern if needed).
+```text
+{ c!(pair(1, 2)) | for(c -> pair($u, $v)){ int($u, 64) } }
+```
 
-**Result.** Same concurrent intuition as current rhocalc **`Comm`**, with **pattern** discipline on each payload.
+**3. Data on the channel**  
+**Message:** **`pair(1, 2)`**. **Pattern:** **`pair($u, $v)`** → **`u ↦ 1`**, **`v ↦ 2`**.
+
+**4. Output and explanation**  
+Residual **`int(1, 64)`**. Changing the payload to **`pair(1, 9)`** still yields **`u ↦ 1`**, **`v ↦ 9`**.
+
+---
+
+### Scenario C — rigid pattern vs wrong-shaped message **(proposal)**
+
+**1. Changes in `rhocalc.rs`**  
+Same as Scenario B.
+
+**2. User’s program**
+
+```text
+{ c!("hi") | for(c -> pair($u, $v)){ int($u, 64) } }
+```
+
+**3. Data on the channel**  
+**Message:** **`"hi"`** (**`Proc`** string). **Pattern:** **`pair($u, $v)`** — requires **`PPair`** head.
+
+**4. Output and explanation**  
+**`unifies_proc`** fails; **`CommPat`** does not consume this pair; **no exception**. (With **`for(c -> $x)`** instead, **`"hi"`** would match an accept-all **`$x`**.)
+
+---
+
+### Scenario D — repeated metavar **`pair($x, $x)`** **(proposal)**
+
+**1. Changes in `rhocalc.rs`**  
+Same as Scenario B.
+
+**Success — 2. User’s program**
+
+```text
+{ c!(pair(3, 3)) | for(c -> pair($x, $x)){ int($x, 64) } }
+```
+
+**3. Data on the channel**  
+**Message:** **`pair(3, 3)`**. **Pattern:** **`pair($x, $x)`** (both arms must agree on **`x`**).
+
+**4. Output and explanation**  
+**`σ = { x ↦ 3 }`**; residual **`int(3, 64)`**.
+
+**Failure — 2. User’s program**
+
+```text
+{ c!(pair(3, 4)) | for(c -> pair($x, $x)){ int($x, 64) } }
+```
+
+**3. Data on the channel**  
+**Message:** **`pair(3, 4)`** — cannot bind **`$x`** to **`3`** and **`4`** at once.
+
+**4. Output and explanation**  
+**`CommPat`** does not fire; send/receive on **`c`** stay in the **`PPar`**.
+
+---
+
+### Scenario E — multi-channel pattern guards **(future sketch)**
+
+**1. Changes in `rhocalc.rs`**
+
+```text
+Comm2 . | unifies(pat1, q1), unifies(pat2, q2)
+    |- (PPar {(PInputs ns pats cont), *zip(ns, qs).*map(|n, q| (POutput n q)), ...rest})
+    ~> (PPar {(apply_pattern_chain cont pats qs), ...rest});
+```
+
+**2. User’s program**
+
+```text
+{ a!(1) | b!(pair(2, 3)) | for(a -> $m){ for(b -> pair($u, $v)){ int($u, 64) } } }
+```
+
+**3. Data on the channel**  
+**`a`:** message **`1`**, pattern **`$m`**. **`b`:** message **`pair(2, 3)`**, pattern **`pair($u, $v)`**.
+
+**4. Output and explanation**  
+If **both** **`unifies`** conjuncts succeed, both sends and the combined receive reduce; conceptually **`m ↦ 1`**, **`u ↦ 2`**, **`v ↦ 3`**. If either fails, this **`Comm2`** step does not apply.
 
 ---
 
@@ -759,7 +730,7 @@ This section highlights **what changes operationally** once pattern matching and
 ### Phase 2: COMM + runtime bindings
 
 - Add `apply_pattern` runtime helper.
-- Introduce **`PPatVar`** / evolved **`PInputs`** (see [Concrete syntax proposal](#concrete-syntax-proposal-for-this-document)) in rhocalc.
+- Introduce **`PPatVar`** / evolved **`PInputs`** (see [Concrete syntax proposal](#concrete-syntax-proposal)) in rhocalc.
 - Implement COMM rewrite using unification premise and `apply_pattern`.
 - Add end-to-end tests for successful/failed communication matches.
 

--- a/docs/design/exploring/unification-premises-for-pattern-comm.md
+++ b/docs/design/exploring/unification-premises-for-pattern-comm.md
@@ -67,7 +67,7 @@ Patterns are **`Proc`** values built from **constructors**. At minimum:
 
 ### PraTT / REPL sugar
 
-REPL examples in this repo historically used **`for(channel -> value){ … }`** style strings (see [repl examples](../../../repl/src/examples/rhocalc.rs)). The target syntax here is **`for(pattern <- channel){ … }`**; extend the grammar so the left side can be a **`Proc` pattern** (e.g. **`for($x <- c){ … }`**, **`for(pair($u, $v) <- c){ … }`**), lowering to the same **`PInputs`**-like constructor as concrete **`( c ? … ).{ … }`** form.
+REPL examples in this repo historically used **`for(channel -> value){ … }`** style strings (see [repl examples](../../../repl/src/examples/rhocalc.rs)). The target syntax here is **`for(pattern <- channel){ … }`**; extend the grammar so the left side can be a **`Proc` pattern** (e.g. **`for($x <- c){ … }`**, **`for(pair($u, $v) <- c){ … }`**), lowering to the same **`PInputs`**-like constructor as concrete **`( value <- channel, … ){ … }`** form.
 
 End-to-end walkthroughs (**`rhocalc.rs` → user program → channel data → output**) are in [Worked examples (four-part layout)](#worked-examples-four-part-layout).
 
@@ -293,7 +293,7 @@ Optional: if category must be visible for disambiguation, reserve `unifies_proc`
 
 ```76:77:languages/src/rhocalc.rs
         PInputs . ns:Vec(Name), ^[xs].p:[Name* -> Proc]
-        |- "(" *zip(ns,xs).*map(|n,x| n "?" x).*sep(",") ")" "." "{" p "}" : Proc ;
+        |- "(" *zip(xs,ns).*map(|x,n| x "<-" n).*sep(",") ")" "{" p "}" : Proc ;
 ```
 
 **Multiset** complexity is already on composition for **outputs**; the gap for “pattern COMM” is **payload / receive patterns** and unification, not “first contact with bags.”
@@ -475,7 +475,7 @@ Receive syntax binds **`Name`** parameters per channel, not arbitrary **`Proc`**
 
 ```76:77:languages/src/rhocalc.rs
         PInputs . ns:Vec(Name), ^[xs].p:[Name* -> Proc]
-        |- "(" *zip(ns,xs).*map(|n,x| n "?" x).*sep(",") ")" "." "{" p "}" : Proc ;
+        |- "(" *zip(xs,ns).*map(|x,n| x "<-" n).*sep(",") ")" "{" p "}" : Proc ;
 ```
 
 **2. User’s program**
@@ -500,7 +500,7 @@ The matching send/receive pair is removed from **`PPar`**; **`cont`** is filled 
 PPatVar . x:Name |- "$" x : Proc;
 
 PInputs . ns:Vec(Name), pats:Vec(Proc), ^[xs].p:[Name* -> Proc]
-    |- "(" *zip(ns, pats).*map(|n, pat| n "?" pat).*sep(",") ")" "." "{" p "}" : Proc ;
+    |- "(" *zip(pats,ns).*map(|pat,n| pat "<-" n).*sep(",") ")" "{" p "}" : Proc ;
 
 CommPat . | unifies(pat, q)
     |- (PPar {(PInputs ns pats cont), *zip(ns, qs).*map(|n, q| (POutput n q)), ...rest})

--- a/docs/design/exploring/unification-premises-for-pattern-comm.md
+++ b/docs/design/exploring/unification-premises-for-pattern-comm.md
@@ -30,6 +30,106 @@ Comm . | pattern unifies received
 
 The intent is to keep “does this match?” inside Ascent/Datalog fixpoint computation, while keeping binding extraction and substitution in deterministic Rust runtime code (see [Logical vs staged realization](#logical-vs-staged-realization)).
 
+## Surfaces: language authors vs REPL users
+
+Pattern matching touches **two** syntactic worlds:
+
+- **Language authors** edit **`language! { … }`** in crates such as [`languages/src/rhocalc.rs`](../../../languages/src/rhocalc.rs): **`terms`**, **`rewrites`** (including **`unifies(pat, recv)`** premises and **`(apply_pattern …)`** on the RHS), **`equations`**, etc. This is **compile-time** macro input; it defines the theory and generated Ascent.
+
+- **End users** (REPL, tests, embeddings) write **object-language** **source** that parses as **`Proc`** (and friends)—for example the strings in [`repl/src/examples/rhocalc.rs`](../../../repl/src/examples/rhocalc.rs). They **do not** type judgement rules or **`unifies(…)`** at the prompt. They only write processes; COMM with unification is triggered **implicitly** when the engine applies the **`Comm`** rewrite produced from `rewrites { … }`.
+
+**Implication:** unification **premises** are **author-facing**; **pattern syntax** (new **`Proc`** constructors and evolved receive forms) is **user-facing**. You cannot get meaningful pattern COMM in the REPL without extending **`terms { … }`** (and usually **`PInputs`**) so patterns and payloads are **shared `Proc`** ASTs that **`unifies_proc`** can relate. See [Concrete syntax proposal](#concrete-syntax-proposal-for-this-document) below.
+
+## Concrete syntax proposal
+
+The following is a **single coherent package** the doc uses for examples. It is a **proposal** until implemented; adjust token choices (`$`, `pair`, …) if they clash with PraTT / lexer rules.
+
+### Meta-level (inside `rewrites { … }`)
+
+| Construct | Proposed form | Role |
+| --------- | ------------- | ---- |
+| Unification premise | **`unifies(pat, recv)`** | Conjunct in `prop_context`; lowers to **`unifies_<cat>(pat, recv)`** in Ascent. |
+| COMM RHS | **`(apply_pattern pat recv body)`** | Parsed like **`eval`** / **`subst`** family; deterministic binding + subst in Rust. |
+| Multi-channel (later) | **`unifies(pat1, recv1), unifies(pat2, recv2), …`** | Same comma-separated conjunction as other premises. |
+
+Reserved: the identifier **`unifies`** in premise position is a **keyword** for **`Premise::Unification`**, not a user-defined `logic { relation unifies … }` (avoid name clashes; validate or document).
+
+### Object-level (inside `terms { … }` — required for matching)
+
+Patterns are **`Proc`** values built from **constructors**. At minimum:
+
+| Construct | Proposed `language!` idea | Surface (user / REPL) | Notes |
+| --------- | ------------------------- | ---------------------- | ----- |
+| Pattern variable | **`PPatVar . x:Name`** | **`$`** **x** | **`$x`** is a **`Proc`** that behaves as a **pattern metavar** in the **first** argument of **`unifies_proc`** (directional matching only). **No** new category: stays **`Proc`**. |
+| Structured match (illustrative) | **`PPair . u:Proc, v:Proc`** | **`pair(`** **u** **`,`** **v** **`)`** | Example binary constructor so examples can use **`pair($u, $v)`** vs **`pair(1, 2)`**; rhocalc may instead reuse **`List`** or add a different product—**the point** is a **ground** shape to recurse under **`unifies_proc`**. |
+
+**Receive form (evolution of `PInputs`).** Today each arm is **`n "?" x`** with **`x`** a **`Name`** binder ([`PInputs` in rhocalc](../../../languages/src/rhocalc.rs)). **Target:** second position is a **`Proc` pattern** **p** (often **`$u`**, **`pair($u,$v)`**, …), with **`^[xs].body`** still abstracting the continuation; **`apply_pattern`** (or a small prelude of **`eval`** steps) connects pattern variables in **p** to occurrences in **body**. Exact **`language!`** typing of **`ps:Vec(Proc)`** vs **`Name* -> Proc`** for **`cont`** is an implementation detail—this doc assumes **aligned vectors** **`ns`**, **`pats`**, **`qs`** in the **`Comm`** LHS, same spirit as current **`ns`**, **`qs`**.
+
+### PraTT / REPL sugar
+
+REPL examples in this repo historically use **`for(a -> x){ … }`** style strings (see [repl examples](../../../repl/src/examples/rhocalc.rs)). **Proposal:** keep that sugar; extend the grammar so **the binding after `->`** can be a **`Proc` pattern** (e.g. **`for(c -> $x){ … }`**, **`for(c -> pair($u, $v)){ … }`**), lowering to the same **`PInputs`**-like constructor as concrete **`( c ? … ).{ … }`** form.
+
+---
+
+### Example — `language!` fragments (author)
+
+**New process constructors (illustrative):**
+
+```text
+PPatVar . x:Name |- "$" x : Proc;
+
+PPair . u:Proc, v:Proc |- "pair" "(" u "," v ")" : Proc;
+```
+
+**Receive constructor (target shape — replaces single `Name` per arm with `Proc` pattern):**
+
+```text
+PInputs . ns:Vec(Name), pats:Vec(Proc), ^[xs].p:[Name* -> Proc]
+    |- "(" *zip(ns, pats).*map(|n, pat| n "?" pat).*sep(",") ")" "." "{" p "}" : Proc ;
+```
+
+**COMM rewrite (single-channel sketch; real rhocalc keeps multiset `...rest`):**
+
+```text
+CommPat . | unifies(pat, q)
+    |- (PPar {(PInputs ns pats cont), *zip(ns, qs).*map(|n, q| (POutput n q)), ...rest})
+    ~> (PPar {(apply_pattern_chain cont pats qs), ...rest});
+```
+
+Here **`apply_pattern_chain`** stands for the generated RHS that walks **aligned `pats`** and **`qs`** (and substitutes into **`cont`**)—either one **n-ary** helper or nested **`apply_pattern`** / **`eval`**; naming is illustrative.
+
+---
+
+### Example — REPL / user programs
+
+Assuming **`$x`** and **`pair`** exist as above, and integer literals are processes (existing casts):
+
+**1) Pattern variable vs literal payload**
+
+```text
+{ c!(7) | for(c -> $x){ int($x, 64) } }
+```
+
+**Intent:** send **`7`** as **`Proc`**; receive matches **`$x`**; continuation runs **`int($x, 64)`** with **`$x`** replaced by the matched value (requires **`int`**’s first argument to accept that **`Proc`** shape—consistent with rhocalc’s numeric **`Proc`** helpers).
+
+**2) Structured pattern**
+
+```text
+{ c!(pair(1, 2)) | for(c -> pair($u, $v)){ int($u, 64) } }
+```
+
+**Intent:** COMM only if payload is **`pair`** of two values; bind **`u`**, **`v`**; run body with those bindings.
+
+**3) No match (stuck w.r.t. this COMM)**
+
+```text
+{ c!("hi") | for(c -> $x){ int($x, 64) } }
+```
+
+**Intent:** if **`$x`** cannot unify with string payload under **`unifies_proc`**, this **`CommPat`** instance does not fire.
+
+Users still **select Rho calculus** in the REPL and paste one **`{ … }`** process; stepping behavior changes only through the **new** **`Comm`** rule and **pattern** grammar.
+
 ## Key design decision: explicit variables instead of implicit binding
 
 ### Two representations
@@ -295,7 +395,7 @@ Ship **keyword surface** `unifies(pat, val)` → **`Premise::Unification`**, **b
 | `macros/src/logic/unification.rs` (new) | Auto-generate structural unification rules per constructor (parallel to congruence generation style).          |
 | `macros/src/logic/rules.rs`             | Lower `Premise::Unification` to `Condition::EnvQuery`-like relation clause generation (new condition variant). |
 | `macros/src/gen/term_ops/`              | Add `apply_pattern` helper for binding extraction + multi-substitution.                                        |
-| `languages/src/rhocalc.rs`              | Add pattern-aware `PFor` form and COMM rewrite using unification premise.                                      |
+| `languages/src/rhocalc.rs`              | Add **`PPatVar`** / **`$x`**, evolve **`PInputs`** for **`Proc`** patterns, optional **`pair`** (or chosen product), and **`CommPat`** with **`unifies`** + **`apply_pattern`** (see [Concrete syntax proposal](#concrete-syntax-proposal-for-this-document)). |
 
 ## AST and Parsing
 
@@ -383,7 +483,7 @@ This yields equational pattern matching while preserving relation-based guards.
 
 COMM rule shape:
 
-1. LHS identifies `(PFor n pattern body)` and `(POutput n received)` in parallel with `...rest`.
+1. LHS identifies a receive form (e.g. **`(PInputs … pattern body)`** in rhocalc; the doc sketch **`PFor n pattern body`** is equivalent intent) and **`(POutput n received)`** in parallel with `...rest`.
 2. Premise includes `unifies_proc(pattern, received)` (or the parsed equivalent).
 3. RHS applies deterministic runtime helper:
    - `apply_pattern(pattern, received, body)` → substituted body.
@@ -450,10 +550,8 @@ Receive syntax binds **`Name`** parameters per channel, not arbitrary **`Proc`**
 // Rholang-like
 for (x <- k) { P }  |  k!(@7)
 
-// rhocalc-like (target): one channel, pattern and payload as Proc
-// Concrete grammar TBD; illustrative shapes:
-//   receive:  (k ? x_pat).{ P }     with x_pat a ProcVar / pattern proc
-//   send:     k!(7)                 as existing output
+// rhocalc / REPL (proposal — see § Concrete syntax proposal):
+//   { k!(7) | for(k -> $x){ … body using $x … } }
 ```
 
 **Rewrite rule (illustrative judgement).** Preferred premise shape from [§1 in Design decisions](#design-decisions-and-recommendations):
@@ -661,7 +759,7 @@ This section highlights **what changes operationally** once pattern matching and
 ### Phase 2: COMM + runtime bindings
 
 - Add `apply_pattern` runtime helper.
-- Introduce/update `PFor` pattern-binder form in rhocalc.
+- Introduce **`PPatVar`** / evolved **`PInputs`** (see [Concrete syntax proposal](#concrete-syntax-proposal-for-this-document)) in rhocalc.
 - Implement COMM rewrite using unification premise and `apply_pattern`.
 - Add end-to-end tests for successful/failed communication matches.
 

--- a/languages/src/rhocalc.rs
+++ b/languages/src/rhocalc.rs
@@ -74,8 +74,8 @@ language! {
         |- n "!" "(" q ")" : Proc ;
 
         // Pattern-based single-input receive used by guarded COMM.
-        PFor . n:Name, pat:Proc, body:Proc
-        |- "for" "(" n "<-" pat ")" "." "{" body "}" : Proc;
+        PFor . pat:Proc, n:Name, body:Proc
+        |- "for" "(" pat "<-" n ")" "{" body "}" : Proc;
 
         PInputs . ns:Vec(Name), ^[xs].p:[Name* -> Proc]
         |- "(" *zip(ns,xs).*map(|n,x| n "?" x).*sep(",") ")" "." "{" p "}" : Proc ;
@@ -823,7 +823,7 @@ language! {
     rewrites {
 
         // Pattern-based communication (single channel): if payload matches pattern, apply substitution into body.
-        CommPattern . | unifies(pat, q) |- (PPar {(PFor n pat body), (POutput n q), ...rest})
+        CommPattern . | unifies(pat, q) |- (PPar {(PFor pat n body), (POutput n q), ...rest})
             ~> (PPar {(apply_pattern pat q body), ...rest});
 
         // communication:

--- a/languages/src/rhocalc.rs
+++ b/languages/src/rhocalc.rs
@@ -73,6 +73,10 @@ language! {
         POutput . n:Name, q:Proc
         |- n "!" "(" q ")" : Proc ;
 
+        // Pattern-based single-input receive used by guarded COMM.
+        PFor . n:Name, pat:Proc, body:Proc
+        |- "for" "(" n "<-" pat ")" "." "{" body "}" : Proc;
+
         PInputs . ns:Vec(Name), ^[xs].p:[Name* -> Proc]
         |- "(" *zip(ns,xs).*map(|n,x| n "?" x).*sep(",") ")" "." "{" p "}" : Proc ;
 
@@ -817,6 +821,10 @@ language! {
     },
 
     rewrites {
+
+        // Pattern-based communication (single channel): if payload matches pattern, apply substitution into body.
+        CommPattern . | unifies(pat, q) |- (PPar {(PFor n pat body), (POutput n q), ...rest})
+            ~> (PPar {(apply_pattern pat q body), ...rest});
 
         // communication:
         // (n1 ? x1 , ... , nk ? xk).{ p } | n1!(q1) | ... | nk!(qk) ~> p(@q1,...,@qk)

--- a/languages/src/rhocalc.rs
+++ b/languages/src/rhocalc.rs
@@ -78,7 +78,7 @@ language! {
         |- "for" "(" pat "<-" n ")" "{" body "}" : Proc;
 
         PInputs . ns:Vec(Name), ^[xs].p:[Name* -> Proc]
-        |- "(" *zip(ns,xs).*map(|n,x| n "?" x).*sep(",") ")" "." "{" p "}" : Proc ;
+        |- "(" *zip(xs,ns).*map(|x,n| x "<-" n).*sep(",") ")" "{" p "}" : Proc ;
 
         NQuote . p:Proc
         |- "@" "(" p ")" : Name ;

--- a/languages/tests/rhocalc_tests.rs
+++ b/languages/tests/rhocalc_tests.rs
@@ -86,6 +86,18 @@ fn assert_no_rewrites(input: &str) {
     );
 }
 
+/// Assert that a term display is never produced among discovered terms.
+fn assert_never_produces(input: &str, forbidden: &str) {
+    let results = run(input);
+    let found = results.all_terms.iter().any(|t| t.display == forbidden);
+    assert!(
+        !found,
+        "`{}` unexpectedly produced `{}`",
+        input,
+        forbidden
+    );
+}
+
 /// Assert that `input` has a rewrite from the initial term (not stuck).
 fn assert_initial_rewrites(input: &str) {
     fresh();
@@ -176,6 +188,18 @@ mod comm {
     fn comm_with_remaining_parallel() {
         // {(c?x).{*(x)} | c!(p) | q} → {p | q}
         assert_reduces_to("{(c?x).{*(x)} | c!(p) | q}", "{p | q}");
+    }
+
+    #[test]
+    fn pattern_comm_var_matches_payload() {
+        assert_reduces_to("{for(c <- x).{x} | c!(p)}", "p");
+    }
+
+    #[test]
+    fn pattern_comm_ground_pattern_blocks_mismatch() {
+        // Pattern 0 does not match payload p, so COMM must not produce {0}.
+        // (Other non-COMM rewrites may exist due HOL/native rules.)
+        assert_never_produces("{for(c <- 0).{0} | c!(p)}", "{0}");
     }
 }
 

--- a/languages/tests/rhocalc_tests.rs
+++ b/languages/tests/rhocalc_tests.rs
@@ -147,47 +147,47 @@ mod comm {
 
     #[test]
     fn single_channel() {
-        assert_reduces_to("{(c?x).{*(x)} | c!(p)}", "p");
+        assert_reduces_to("{(x <- c){*(x)} | c!(p)}", "p");
     }
 
     #[test]
     fn comm_with_body_using_channel() {
-        assert_reduces_to("{(c?x).{x!(0)} | c!(p)}", "p!(0)");
+        assert_reduces_to("{(x <- c){x!(0)} | c!(p)}", "p!(0)");
     }
 
     #[test]
     fn comm_substitutes_quoted_value() {
-        // Comm: (c?x).{*(x)} | c!(0) → *(@ (0)) → 0
-        assert_reduces_to("{(c?x).{*(x)} | c!(0)}", "0");
+        // Comm: (x <- c){*(x)} | c!(0) → *(@ (0)) → 0
+        assert_reduces_to("{(x <- c){*(x)} | c!(0)}", "0");
     }
 
     #[test]
     fn multi_input_two_channels() {
-        assert_reduces_to("{(c1?x, c2?y).{*(x)} | c1!(p) | c2!(q)}", "p");
+        assert_reduces_to("{(x <- c1, y <- c2){*(x)} | c1!(p) | c2!(q)}", "p");
     }
 
     #[test]
     fn multi_input_uses_both_vars() {
-        assert_reduces_to("{(c1?x, c2?y).{{*(x) | *(y)}} | c1!(p) | c2!(q)}", "p");
+        assert_reduces_to("{(x <- c1, y <- c2){{*(x) | *(y)}} | c1!(p) | c2!(q)}", "p");
     }
 
     #[test]
     fn multi_input_three_channels() {
         assert_reduces_to(
-            "{(a?x, b?y, c?z).{{*(x) | *(y) | *(z)}} | a!(p) | b!(q) | c!(r)}",
+            "{(x <- a, y <- b, z <- c){{*(x) | *(y) | *(z)}} | a!(p) | b!(q) | c!(r)}",
             "{p | q | r}",
         );
     }
 
     #[test]
     fn join_pattern_same_channel() {
-        assert_reduces_to("{(c?x, c?y).{{*(x) | *(y)}} | c!(a) | c!(b)}", "{a | b}");
+        assert_reduces_to("{(x <- c, y <- c){{*(x) | *(y)}} | c!(a) | c!(b)}", "{a | b}");
     }
 
     #[test]
     fn comm_with_remaining_parallel() {
-        // {(c?x).{*(x)} | c!(p) | q} → {p | q}
-        assert_reduces_to("{(c?x).{*(x)} | c!(p) | q}", "{p | q}");
+        // {(x <- c){*(x)} | c!(p) | q} → {p | q}
+        assert_reduces_to("{(x <- c){*(x)} | c!(p) | q}", "{p | q}");
     }
 
     #[test]
@@ -282,35 +282,35 @@ mod new_and_extrusion {
 
     #[test]
     fn new_congruence_propagates_body_rewrite() {
-        // new(x) in { {(a?z).{*(z)} | a!(0)} } → new(x) in { {*(@(0))} } → ...
-        assert_min_rewrites("new(x) in { {(a?z).{*(z)} | a!(0)} }", 1);
+        // new(x) in { {(z <- a){*(z)} | a!(0)} } → new(x) in { {*(@(0))} } → ...
+        assert_min_rewrites("new(x) in { {(z <- a){*(z)} | a!(0)} }", 1);
     }
 
     #[test]
     fn new_congruence_reaches_normal_form() {
-        assert_reduces_to("new(x) in { {(a?z).{*(z)} | a!(0)} }", "new(x) in { 0 }");
+        assert_reduces_to("new(x) in { {(z <- a){*(z)} | a!(0)} }", "new(x) in { 0 }");
     }
 
     #[test]
     fn extrusion_forward() {
         // {new(x) in {p} | a!(0)} = new(x) in {{p | a!(0)}}
         // The initial PPar should connect to a rewrite (via equation + congruence).
-        assert_initial_rewrites("{new(x) in { (a?z).{*(z)} } | a!(0)}");
+        assert_initial_rewrites("{new(x) in { (z <- a){*(z)} } | a!(0)}");
     }
 
     #[test]
     fn extrusion_reaches_result() {
-        // {new(x) in {(a?z).{*(z)}} | a!(0)}
-        //  =extrude= new(x) in {{(a?z).{*(z)} | a!(0)}}
+        // {new(x) in {(z <- a){*(z)}} | a!(0)}
+        //  =extrude= new(x) in {{(z <- a){*(z)} | a!(0)}}
         //  →comm→ new(x) in {{*(@(0))}} →exec→ new(x) in {0}
-        assert_reduces_to("{new(x) in { (a?z).{*(z)} } | a!(0)}", "new(x) in { 0 }");
+        assert_reduces_to("{new(x) in { (z <- a){*(z)} } | a!(0)}", "new(x) in { 0 }");
     }
 
     #[test]
     fn extrusion_blocked_when_not_fresh() {
-        // {new(a) in {(a?z).{*(z)}} | a!(0)} — x=a is NOT fresh in a!(0),
+        // {new(a) in {(z <- a){*(z)}} | a!(0)} — x=a is NOT fresh in a!(0),
         // so extrusion should not apply. The term is stuck.
-        let results = run("{new(a) in { (a?z).{*(z)} } | a!(0)}");
+        let results = run("{new(a) in { (z <- a){*(z)} } | a!(0)}");
         let nfs = normal_form_displays(&results);
         // Should be a normal form as-is (no extrusion possible)
         assert!(!nfs.is_empty(), "blocked extrusion should still have normal forms");
@@ -742,7 +742,7 @@ mod native_ops {
         #[test]
         fn remove_comm() {
             assert_reduces_to(
-                "{a!(#{1|2|2}#) | c!(2) | (a?b, c?e).{remove(*(b), *(e))}}",
+                "{a!(#{1|2|2}#) | c!(2) | (b <- a, e <- c){remove(*(b), *(e))}}",
                 "#{1|2}#",
             );
         }
@@ -750,7 +750,7 @@ mod native_ops {
         /// count(*(bag), *(elem)) after comm: counts occurrences of elem in bag
         #[test]
         fn count_comm() {
-            assert_reduces_to("{a!(#{1|2|2}#) | c!(2) | (a?b, c?e).{count(*(b), *(e))}}", "2");
+            assert_reduces_to("{a!(#{1|2|2}#) | c!(2) | (b <- a, e <- c){count(*(b), *(e))}}", "2");
         }
     }
 
@@ -871,11 +871,18 @@ mod parsing {
     }
     #[test]
     fn receive() {
-        let _ = run("(x?y).{y!(0)}");
+        let _ = run("(y <- x){y!(0)}");
     }
     #[test]
     fn multi_input() {
-        let _ = run("{(c1?x, c2?y).{*(x)} | c1!(p) | c2!(q)}");
+        let _ = run("{(x <- c1, y <- c2){*(x)} | c1!(p) | c2!(q)}");
+    }
+
+    #[test]
+    fn old_receive_syntax_rejected() {
+        let lang = RhoCalcLanguage;
+        assert!(lang.parse_term("(c?x).{x!(0)}").is_err());
+        assert!(lang.parse_term("(c1?x, c2?y).{*(x)}").is_err());
     }
     #[test]
     fn new_single() {
@@ -1068,7 +1075,7 @@ fn rhocalc_cast_uint_signed_int_twos_complement() {
 
 #[test]
 fn rhocalc_cast_under_send_reduces_via_comm() {
-    let results = run("{(c?x).{*(x)} | c!({int(-3.5, 8)})}");
+    let results = run("{(x <- c){*(x)} | c!({int(-3.5, 8)})}");
     let nfs = normal_form_displays(&results);
     assert!(
         nfs.iter().any(|nf| nf == "-4" || nf.contains("-4")),
@@ -1088,7 +1095,7 @@ mod type_inference {
     fn pinputs_infers_bound_var() {
         fresh();
         let lang = RhoCalcLanguage;
-        let term = lang.parse_term("(x?y).{*(y)}").expect("parse");
+        let term = lang.parse_term("(y <- x){*(y)}").expect("parse");
         let var_types = lang.infer_var_types(term.as_ref());
         let y_info = var_types.iter().find(|v| v.name == "y");
         assert!(y_info.is_some(), "y should be found, got: {:?}", var_types);
@@ -1099,7 +1106,7 @@ mod type_inference {
     fn pinputs_lookup_by_name() {
         fresh();
         let lang = RhoCalcLanguage;
-        let term = lang.parse_term("(x?y).{*(y)}").expect("parse");
+        let term = lang.parse_term("(y <- x){*(y)}").expect("parse");
         let y_type = lang.infer_var_type(term.as_ref(), "y");
         assert!(y_type.is_some());
         assert_eq!(format!("{}", y_type.unwrap()), "Name");
@@ -1109,7 +1116,7 @@ mod type_inference {
     fn multi_input_infers_both_vars() {
         fresh();
         let lang = RhoCalcLanguage;
-        let term = lang.parse_term("(c1?x, c2?y).{*(x)}").expect("parse");
+        let term = lang.parse_term("(x <- c1, y <- c2){*(x)}").expect("parse");
         let var_types = lang.infer_var_types(term.as_ref());
         assert!(var_types.iter().any(|v| v.name == "x"));
         assert!(var_types.iter().any(|v| v.name == "y"));

--- a/languages/tests/rhocalc_tests.rs
+++ b/languages/tests/rhocalc_tests.rs
@@ -196,11 +196,66 @@ mod comm {
     }
 
     #[test]
+    fn pattern_comm_ground_pattern_matches_equal_payload() {
+        assert_reduces_to("{for(0 <- c){1} | c!(0)}", "1");
+    }
+
+    #[test]
+    fn pattern_comm_exact_constructor_pattern_matches() {
+        assert_reduces_to("{for(*(@(0)) <- c){1} | c!(*(@(0)))}", "1");
+    }
+
+    #[test]
     fn pattern_comm_ground_pattern_blocks_mismatch() {
         // Pattern 0 does not match payload p, so COMM must not produce {0}.
         // (Other non-COMM rewrites may exist due HOL/native rules.)
         assert_never_produces("{for(0 <- c){0} | c!(p)}", "{0}");
     }
+
+    #[test]
+    fn pattern_comm_list_literal_pattern_matches() {
+        assert_reduces_to("{for([0, 1] <- c){42} | c!([0, 1])}", "42");
+    }
+
+    #[test]
+    fn pattern_comm_list_literal_pattern_blocks_mismatch() {
+        assert_never_produces("{for([0, 1] <- c){42} | c!([0, 1, 2])}", "{42}");
+    }
+
+    #[test]
+    fn pattern_comm_bag_literal_pattern_matches() {
+        assert_reduces_to("{for(#{1|2}# <- c){7} | c!(#{2|1}#)}", "7");
+    }
+
+    #[test]
+    fn pattern_comm_bag_literal_pattern_blocks_mismatch() {
+        assert_never_produces("{for(#{1|2}# <- c){7} | c!(#{1|1}#)}", "{7}");
+    }
+
+    #[test]
+    fn pattern_comm_map_literal_pattern_matches() {
+        assert_reduces_to("{for(map(1:2, 3:4) <- c){9} | c!(map(3:4, 1:2))}", "9");
+    }
+
+    #[test]
+    fn pattern_comm_map_literal_pattern_blocks_mismatch() {
+        assert_never_produces("{for(map(1:2, 3:4) <- c){9} | c!(map(1:2, 3:5))}", "{9}");
+    }
+
+    #[test]
+    fn proc_pattern_matches_list_is_strict() {
+        let pat = parse("[0, 1]");
+        let val = parse("[0, 1, 2]");
+        assert!(!pat.pattern_matches(&val));
+    }
+
+    #[test]
+    fn proc_pattern_matches_map_is_strict() {
+        let pat = parse("map(1:2, 3:4)");
+        let val = parse("map(1:2, 3:5)");
+        assert!(!pat.pattern_matches(&val));
+    }
+
 }
 
 // ════════════════════════════════════════════════════════════════════════════════

--- a/languages/tests/rhocalc_tests.rs
+++ b/languages/tests/rhocalc_tests.rs
@@ -192,14 +192,14 @@ mod comm {
 
     #[test]
     fn pattern_comm_var_matches_payload() {
-        assert_reduces_to("{for(c <- x).{x} | c!(p)}", "p");
+        assert_reduces_to("{for(x <- c){x} | c!(p)}", "p");
     }
 
     #[test]
     fn pattern_comm_ground_pattern_blocks_mismatch() {
         // Pattern 0 does not match payload p, so COMM must not produce {0}.
         // (Other non-COMM rewrites may exist due HOL/native rules.)
-        assert_never_produces("{for(c <- 0).{0} | c!(p)}", "{0}");
+        assert_never_produces("{for(0 <- c){0} | c!(p)}", "{0}");
     }
 }
 

--- a/languages/tests/rhocalc_tests.rs
+++ b/languages/tests/rhocalc_tests.rs
@@ -90,12 +90,7 @@ fn assert_no_rewrites(input: &str) {
 fn assert_never_produces(input: &str, forbidden: &str) {
     let results = run(input);
     let found = results.all_terms.iter().any(|t| t.display == forbidden);
-    assert!(
-        !found,
-        "`{}` unexpectedly produced `{}`",
-        input,
-        forbidden
-    );
+    assert!(!found, "`{}` unexpectedly produced `{}`", input, forbidden);
 }
 
 /// Assert that `input` has a rewrite from the initial term (not stuck).
@@ -255,7 +250,6 @@ mod comm {
         let val = parse("map(1:2, 3:5)");
         assert!(!pat.pattern_matches(&val));
     }
-
 }
 
 // ════════════════════════════════════════════════════════════════════════════════

--- a/macros/src/ast/language.rs
+++ b/macros/src/ast/language.rs
@@ -87,6 +87,9 @@ pub enum Premise {
     /// Currently used for env_var(x, v), extensible to arbitrary relations
     RelationQuery { relation: Ident, args: Vec<Ident> },
 
+    /// Directional unification/matching: unifies(pattern, value)
+    Unification { pattern: Ident, value: Ident },
+
     /// Universal quantification over a collection: xs.*map(|x| premise)
     /// Means "for all x in xs, premise holds"
     ForAll {
@@ -147,6 +150,8 @@ pub enum Condition {
         /// Arguments to the relation (e.g., ["x", "v"])
         args: Vec<Ident>,
     },
+    /// Directional unification guard: unifies(pattern, value)
+    Unification { pattern: Ident, value: Ident },
     /// Universal quantification: for all x in collection, body holds
     ForAll {
         collection: Ident,
@@ -885,7 +890,7 @@ fn parse_premise(input: ParseStream) -> SynResult<Premise> {
         let target = input.parse::<Ident>()?;
         Ok(Premise::Congruence { source: first, target })
     } else if input.peek(syn::token::Paren) {
-        // Relation query: rel(args)
+        // Relation query or reserved unification: ident(args)
         let args_content;
         syn::parenthesized!(args_content in input);
         let mut args = Vec::new();
@@ -895,7 +900,20 @@ fn parse_premise(input: ParseStream) -> SynResult<Premise> {
                 let _ = args_content.parse::<Token![,]>()?;
             }
         }
-        Ok(Premise::RelationQuery { relation: first, args })
+        if first == "unifies" {
+            if args.len() != 2 {
+                return Err(syn::Error::new(
+                    first.span(),
+                    "unifies(...) requires exactly 2 identifiers: unifies(pattern, value)",
+                ));
+            }
+            Ok(Premise::Unification {
+                pattern: args[0].clone(),
+                value: args[1].clone(),
+            })
+        } else {
+            Ok(Premise::RelationQuery { relation: first, args })
+        }
     } else if input.peek(Token![.]) {
         // ForAll: xs.*map(|x| premise)
         let _ = input.parse::<Token![.]>()?;
@@ -921,7 +939,7 @@ fn parse_premise(input: ParseStream) -> SynResult<Premise> {
     } else {
         Err(syn::Error::new(
             first.span(),
-            "expected premise: 'x # term', 'S ~> T', 'rel(args)', or 'xs.*map(|x| ...)'",
+            "expected premise: 'x # term', 'S ~> T', 'unifies(pat, val)', 'rel(args)', or 'xs.*map(|x| ...)'",
         ))
     }
 }
@@ -1148,6 +1166,23 @@ pub fn parse_pattern(input: ParseStream) -> SynResult<Pattern> {
                     replacement: Box::new(replacement),
                 }));
             }
+        }
+
+        if constructor == "apply_pattern" {
+            let pattern = parse_pattern(&content)?;
+            let value = parse_pattern(&content)?;
+            let body = parse_pattern(&content)?;
+            if !content.is_empty() {
+                return Err(syn::Error::new(
+                    constructor.span(),
+                    "apply_pattern takes exactly 3 arguments: (apply_pattern pattern value body)",
+                ));
+            }
+            return Ok(Pattern::Term(PatternTerm::ApplyPattern {
+                pattern: Box::new(pattern),
+                value: Box::new(value),
+                body: Box::new(body),
+            }));
         }
 
         // Parse arguments as nested patterns

--- a/macros/src/ast/pattern.rs
+++ b/macros/src/ast/pattern.rs
@@ -48,6 +48,13 @@ pub enum PatternTerm {
         scope: Box<Pattern>,
         replacements: Vec<Pattern>,
     },
+
+    /// Apply pattern bindings from `pattern` and `value` into `body`.
+    ApplyPattern {
+        pattern: Box<Pattern>,
+        value: Box<Pattern>,
+        body: Box<Pattern>,
+    },
 }
 
 /// Pattern for rule specification (both LHS and RHS).
@@ -149,6 +156,12 @@ impl PatternTerm {
                 for repl in replacements {
                     vars.extend(repl.free_vars());
                 }
+                vars
+            },
+            PatternTerm::ApplyPattern { pattern, value, body } => {
+                let mut vars = pattern.free_vars();
+                vars.extend(value.free_vars());
+                vars.extend(body.free_vars());
                 vars
             },
         }
@@ -287,6 +300,7 @@ impl PatternTerm {
             PatternTerm::MultiLambda { body, .. } => body.category(language),
             PatternTerm::Subst { term, .. } => term.category(language),
             PatternTerm::MultiSubst { scope, .. } => scope.category(language),
+            PatternTerm::ApplyPattern { body, .. } => body.category(language),
         }
     }
 
@@ -329,6 +343,11 @@ impl PatternTerm {
                 for repl in replacements {
                     repl.collect_var_occurrences(counts);
                 }
+            },
+            PatternTerm::ApplyPattern { pattern, value, body } => {
+                pattern.collect_var_occurrences(counts);
+                value.collect_var_occurrences(counts);
+                body.collect_var_occurrences(counts);
             },
         }
     }
@@ -1301,6 +1320,9 @@ impl PatternTerm {
             PatternTerm::MultiSubst { .. } => {
                 unimplemented!("MultiSubst in LHS patterns not supported")
             },
+            PatternTerm::ApplyPattern { .. } => {
+                unimplemented!("ApplyPattern in LHS patterns not supported")
+            },
         }
     }
 }
@@ -2126,6 +2148,16 @@ impl PatternTerm {
                             (*__body).#subst_method(&__vars, &__repls)
                         }
                     }
+                }
+            },
+            PatternTerm::ApplyPattern { pattern, value, body } => {
+                let pattern_expr = pattern.to_ascent_rhs(bindings, language);
+                let value_expr = value.to_ascent_rhs(bindings, language);
+                let body_expr = body.to_ascent_rhs(bindings, language);
+                quote! {
+                    (#body_expr)
+                        .apply_pattern(&(#pattern_expr), &(#value_expr))
+                        .unwrap_or_else(|| (#body_expr).clone())
                 }
             },
         }

--- a/macros/src/ast/validation/typechecker.rs
+++ b/macros/src/ast/validation/typechecker.rs
@@ -197,6 +197,7 @@ impl TypeChecker {
             PatternTerm::MultiLambda { body, .. } => self.infer_type_from_pattern(body, context),
             PatternTerm::Subst { term, .. } => self.infer_type_from_pattern(term, context),
             PatternTerm::MultiSubst { scope, .. } => self.infer_type_from_pattern(scope, context),
+            PatternTerm::ApplyPattern { body, .. } => self.infer_type_from_pattern(body, context),
         }
     }
 

--- a/macros/src/ast/validation/validator.rs
+++ b/macros/src/ast/validation/validator.rs
@@ -179,6 +179,12 @@ fn validate_pattern_term(pt: &PatternTerm, language: &LanguageDef) -> Result<(),
             }
             Ok(())
         },
+        PatternTerm::ApplyPattern { pattern, value, body } => {
+            validate_pattern(pattern, language)?;
+            validate_pattern(value, language)?;
+            validate_pattern(body, language)?;
+            Ok(())
+        },
     }
 }
 
@@ -236,6 +242,23 @@ fn validate_premise(
             validate_premise(body, pattern_vars, &inner_bound)?;
         },
         Premise::Congruence { .. } | Premise::RelationQuery { .. } => {},
+        Premise::Unification { pattern, value } => {
+            let pat = pattern.to_string();
+            let val = value.to_string();
+            let in_scope = |name: &str| pattern_vars.contains(name) || bound_vars.contains(name);
+            if !in_scope(&pat) {
+                return Err(ValidationError::FreshnessVariableNotInEquation {
+                    var: pat,
+                    span: pattern.span(),
+                });
+            }
+            if !in_scope(&val) {
+                return Err(ValidationError::FreshnessVariableNotInEquation {
+                    var: val,
+                    span: value.span(),
+                });
+            }
+        },
     }
     Ok(())
 }
@@ -340,6 +363,11 @@ fn collect_pattern_term_vars(pt: &PatternTerm, vars: &mut HashSet<String>) {
             for repl in replacements {
                 collect_pattern_vars(repl, vars);
             }
+        },
+        PatternTerm::ApplyPattern { pattern, value, body } => {
+            collect_pattern_vars(pattern, vars);
+            collect_pattern_vars(value, vars);
+            collect_pattern_vars(body, vars);
         },
     }
 }

--- a/macros/src/gen/runtime/metadata.rs
+++ b/macros/src/gen/runtime/metadata.rs
@@ -417,6 +417,9 @@ fn premise_to_display_string(p: &Premise) -> String {
         Premise::Congruence { source, target } => {
             format!("{} ~> {}", source, target)
         },
+        Premise::Unification { pattern, value } => {
+            format!("unifies({}, {})", pattern, value)
+        },
         Premise::ForAll { collection, param, body } => {
             format!("{}.*map(|{}| {})", collection, param, premise_to_display_string(body))
         },
@@ -606,6 +609,12 @@ fn pattern_term_to_syntax(pt: &PatternTerm, language: &LanguageDef) -> String {
                 .map(|r| pattern_to_user_syntax(r, language))
                 .collect();
             format!("{}[{}]", scope_str, repls.join(", "))
+        },
+        PatternTerm::ApplyPattern { pattern, value, body } => {
+            let p = pattern_to_user_syntax(pattern, language);
+            let v = pattern_to_user_syntax(value, language);
+            let b = pattern_to_user_syntax(body, language);
+            format!("apply_pattern({}, {}, {})", p, v, b)
         },
     }
 }

--- a/macros/src/gen/term_ops/subst.rs
+++ b/macros/src/gen/term_ops/subst.rs
@@ -1412,6 +1412,7 @@ fn generate_subst_impl(
     language: &LanguageDef,
 ) -> TokenStream {
     let category_str = category.to_string();
+    let var_label = generate_var_label(category);
 
     // Generate match arms for the main subst method (same-category)
     let match_arms: Vec<TokenStream> = variants
@@ -1542,6 +1543,22 @@ fn generate_subst_impl(
                 repls: &[Self],
             ) -> Self {
                 self.subst(vars, repls)
+            }
+
+            /// Pattern-application helper used by COMM-style RHS expressions.
+            ///
+            /// Minimal phase-2 semantics:
+            /// - if `pattern` is a free variable, substitute that variable with `value` in `self`
+            /// - if `pattern == value`, return `self` unchanged
+            /// - otherwise no match (`None`)
+            pub fn apply_pattern(&self, pattern: &Self, value: &Self) -> Option<Self> {
+                match pattern {
+                    #category::#var_label(mettail_runtime::OrdVar(mettail_runtime::Var::Free(fv))) => {
+                        Some(self.substitute(fv, value))
+                    }
+                    _ if pattern == value => Some(self.clone()),
+                    _ => None,
+                }
             }
 
             #(#cross_methods)*

--- a/macros/src/gen/term_ops/subst.rs
+++ b/macros/src/gen/term_ops/subst.rs
@@ -1413,6 +1413,52 @@ fn generate_subst_impl(
 ) -> TokenStream {
     let category_str = category.to_string();
     let var_label = generate_var_label(category);
+    let is_proc = category_str == "Proc";
+    let has_list = language.types.iter().any(|t| t.name.to_string() == "List");
+    let has_bag = language.types.iter().any(|t| t.name.to_string() == "Bag");
+    let has_map = language.types.iter().any(|t| t.name.to_string() == "Map");
+    let proc_list_ctor: Option<Ident> = if is_proc {
+        variants.iter().find_map(|v| match v {
+            VariantKind::Regular { label, fields }
+                if fields.len() == 1
+                    && !fields[0].is_collection
+                    && fields[0].category.to_string() == "List" =>
+            {
+                Some(label.clone())
+            }
+            _ => None,
+        })
+    } else {
+        None
+    };
+    let proc_bag_ctor: Option<Ident> = if is_proc {
+        variants.iter().find_map(|v| match v {
+            VariantKind::Regular { label, fields }
+                if fields.len() == 1
+                    && !fields[0].is_collection
+                    && fields[0].category.to_string() == "Bag" =>
+            {
+                Some(label.clone())
+            }
+            _ => None,
+        })
+    } else {
+        None
+    };
+    let proc_map_ctor: Option<Ident> = if is_proc {
+        variants.iter().find_map(|v| match v {
+            VariantKind::Regular { label, fields }
+                if fields.len() == 1
+                    && !fields[0].is_collection
+                    && fields[0].category.to_string() == "Map" =>
+            {
+                Some(label.clone())
+            }
+            _ => None,
+        })
+    } else {
+        None
+    };
 
     // Generate match arms for the main subst method (same-category)
     let match_arms: Vec<TokenStream> = variants
@@ -1480,6 +1526,204 @@ fn generate_subst_impl(
     let substitute_self_alias = format_ident!("substitute_{}", category_str.to_lowercase());
     let multi_substitute_self_alias =
         format_ident!("multi_substitute_{}", category_str.to_lowercase());
+    let pattern_helpers = if is_proc {
+        let list_arm = if let Some(list_ctor) = proc_list_ctor.as_ref() {
+            quote! { (Proc::#list_ctor(p), Proc::#list_ctor(v)) => Self::match_list_pattern(p.as_ref(), v.as_ref(), env), }
+        } else {
+            quote! {}
+        };
+        let bag_arm = if let Some(bag_ctor) = proc_bag_ctor.as_ref() {
+            quote! { (Proc::#bag_ctor(p), Proc::#bag_ctor(v)) => Self::match_bag_pattern(p.as_ref(), v.as_ref(), env), }
+        } else {
+            quote! {}
+        };
+        let map_arm = if let Some(map_ctor) = proc_map_ctor.as_ref() {
+            quote! { (Proc::#map_ctor(p), Proc::#map_ctor(v)) => Self::match_map_pattern(p.as_ref(), v.as_ref(), env), }
+        } else {
+            quote! {}
+        };
+        let list_helper = if has_list {
+            quote! {
+                fn match_list_pattern(
+                    pat: &List,
+                    val: &List,
+                    env: &mut std::collections::HashMap<mettail_runtime::FreeVar<String>, Self>,
+                ) -> bool {
+                    match (pat, val) {
+                        (List::ListLit(ps), List::ListLit(vs)) => {
+                            ps.len() == vs.len()
+                                && ps
+                                    .iter()
+                                    .zip(vs.iter())
+                                    .all(|(p, v)| Self::collect_pattern_bindings(p, v, env))
+                        }
+                        _ => pat == val,
+                    }
+                }
+            }
+        } else {
+            quote! {}
+        };
+        let bag_helper = if has_bag {
+            quote! {
+                fn match_bag_pattern(
+                    pat: &Bag,
+                    val: &Bag,
+                    env: &mut std::collections::HashMap<mettail_runtime::FreeVar<String>, Self>,
+                ) -> bool {
+                    match (pat, val) {
+                        (Bag::BagLit(pb), Bag::BagLit(vb)) => {
+                            let mut pats = Vec::new();
+                            for (e, count) in pb.iter() {
+                                for _ in 0..count {
+                                    pats.push(e.clone());
+                                }
+                            }
+                            let mut vals = Vec::new();
+                            for (e, count) in vb.iter() {
+                                for _ in 0..count {
+                                    vals.push(e.clone());
+                                }
+                            }
+                            Self::match_proc_bag_permutation(&pats, &vals, env)
+                        }
+                        _ => pat == val,
+                    }
+                }
+            }
+        } else {
+            quote! {}
+        };
+        let map_helper = if has_map {
+            quote! {
+                fn match_map_pattern(
+                    pat: &Map,
+                    val: &Map,
+                    env: &mut std::collections::HashMap<mettail_runtime::FreeVar<String>, Self>,
+                ) -> bool {
+                    match (pat, val) {
+                        (Map::MapLit(pm), Map::MapLit(vm)) => {
+                            pm.len() == vm.len()
+                                && pm.iter().all(|(k, pvv)| {
+                                    vm.get(k)
+                                        .map(|vv| Self::collect_pattern_bindings(pvv, vv, env))
+                                        .unwrap_or(false)
+                                })
+                        }
+                        _ => pat == val,
+                    }
+                }
+            }
+        } else {
+            quote! {}
+        };
+        quote! {
+            fn collect_pattern_bindings(
+                pattern: &Self,
+                value: &Self,
+                env: &mut std::collections::HashMap<mettail_runtime::FreeVar<String>, Self>,
+            ) -> bool {
+                match (pattern, value) {
+                    (Proc::PVar(mettail_runtime::OrdVar(mettail_runtime::Var::Free(fv))), v) => {
+                        if let Some(bound) = env.get(fv) {
+                            bound == v
+                        } else {
+                            env.insert(fv.clone(), v.clone());
+                            true
+                        }
+                    }
+                    #list_arm
+                    #bag_arm
+                    #map_arm
+                    _ => pattern == value,
+                }
+            }
+
+            fn match_proc_bag_permutation(
+                pats: &[Self],
+                vals: &[Self],
+                env: &mut std::collections::HashMap<mettail_runtime::FreeVar<String>, Self>,
+            ) -> bool {
+                if pats.len() != vals.len() {
+                    return false;
+                }
+                fn bt(
+                    idx: usize,
+                    pats: &[Proc],
+                    vals: &[Proc],
+                    used: &mut [bool],
+                    env: &mut std::collections::HashMap<mettail_runtime::FreeVar<String>, Proc>,
+                ) -> bool {
+                    if idx == pats.len() {
+                        return true;
+                    }
+                    for j in 0..vals.len() {
+                        if used[j] {
+                            continue;
+                        }
+                        let mut env_try = env.clone();
+                        if Proc::collect_pattern_bindings(&pats[idx], &vals[j], &mut env_try) {
+                            used[j] = true;
+                            if bt(idx + 1, pats, vals, used, &mut env_try) {
+                                *env = env_try;
+                                return true;
+                            }
+                            used[j] = false;
+                        }
+                    }
+                    false
+                }
+                let mut used = vec![false; vals.len()];
+                bt(0, pats, vals, &mut used, env)
+            }
+
+            #list_helper
+            #bag_helper
+            #map_helper
+        }
+    } else {
+        quote! {}
+    };
+    let pattern_matches_body = if is_proc {
+        quote! {
+            let mut env: std::collections::HashMap<mettail_runtime::FreeVar<String>, Self> =
+                std::collections::HashMap::new();
+            Self::collect_pattern_bindings(self, value, &mut env)
+        }
+    } else {
+        quote! {
+            match self {
+                #category::#var_label(mettail_runtime::OrdVar(mettail_runtime::Var::Free(_))) => true,
+                _ => self == value,
+            }
+        }
+    };
+    let apply_pattern_body = if is_proc {
+        quote! {
+            let mut env: std::collections::HashMap<mettail_runtime::FreeVar<String>, Self> =
+                std::collections::HashMap::new();
+            if !Self::collect_pattern_bindings(pattern, value, &mut env) {
+                return None;
+            }
+            let vars_owned: Vec<mettail_runtime::FreeVar<String>> = env.keys().cloned().collect();
+            let vars_refs: Vec<&mettail_runtime::FreeVar<String>> = vars_owned.iter().collect();
+            let repls: Vec<Self> = vars_owned
+                .iter()
+                .map(|v| env.get(v).cloned().expect("binding exists"))
+                .collect();
+            Some(self.subst(&vars_refs, &repls))
+        }
+    } else {
+        quote! {
+            match pattern {
+                #category::#var_label(mettail_runtime::OrdVar(mettail_runtime::Var::Free(fv))) => {
+                    Some(self.substitute(fv, value))
+                }
+                _ if pattern == value => Some(self.clone()),
+                _ => None,
+            }
+        }
+    };
 
     quote! {
         impl #category {
@@ -1545,22 +1789,17 @@ fn generate_subst_impl(
                 self.subst(vars, repls)
             }
 
-            /// Pattern-application helper used by COMM-style RHS expressions.
-            ///
-            /// Minimal phase-2 semantics:
-            /// - if `pattern` is a free variable, substitute that variable with `value` in `self`
-            /// - if `pattern == value`, return `self` unchanged
-            /// - otherwise no match (`None`)
-            pub fn apply_pattern(&self, pattern: &Self, value: &Self) -> Option<Self> {
-                match pattern {
-                    #category::#var_label(mettail_runtime::OrdVar(mettail_runtime::Var::Free(fv))) => {
-                        Some(self.substitute(fv, value))
-                    }
-                    _ if pattern == value => Some(self.clone()),
-                    _ => None,
-                }
+            /// Directional structural match used by unification premises.
+            pub fn pattern_matches(&self, value: &Self) -> bool {
+                #pattern_matches_body
             }
 
+            /// Pattern-application helper used by COMM-style RHS expressions.
+            pub fn apply_pattern(&self, pattern: &Self, value: &Self) -> Option<Self> {
+                #apply_pattern_body
+            }
+
+            #pattern_helpers
             #(#cross_methods)*
         }
     }

--- a/macros/src/gen/term_ops/subst.rs
+++ b/macros/src/gen/term_ops/subst.rs
@@ -1425,7 +1425,7 @@ fn generate_subst_impl(
                     && fields[0].category.to_string() == "List" =>
             {
                 Some(label.clone())
-            }
+            },
             _ => None,
         })
     } else {
@@ -1439,7 +1439,7 @@ fn generate_subst_impl(
                     && fields[0].category.to_string() == "Bag" =>
             {
                 Some(label.clone())
-            }
+            },
             _ => None,
         })
     } else {
@@ -1453,7 +1453,7 @@ fn generate_subst_impl(
                     && fields[0].category.to_string() == "Map" =>
             {
                 Some(label.clone())
-            }
+            },
             _ => None,
         })
     } else {

--- a/macros/src/logic/mod.rs
+++ b/macros/src/logic/mod.rs
@@ -145,6 +145,7 @@ pub fn generate_ascent_source(language: &LanguageDef) -> AscentSourceOutput {
 }
 
 /// Format Ascent source for display and file output
+#[allow(clippy::too_many_arguments)]
 fn format_ascent_source(
     theory_name: &str,
     source_name: &Ident,

--- a/macros/src/logic/mod.rs
+++ b/macros/src/logic/mod.rs
@@ -29,6 +29,7 @@ pub mod common;
 mod equations;
 pub mod helpers;
 mod relations;
+mod unification;
 mod writer;
 
 pub mod congruence;
@@ -38,6 +39,7 @@ pub mod rules;
 pub use categories::generate_category_rules;
 pub use equations::generate_equation_rules;
 pub use relations::{generate_relations, list_all_relations_for_extraction};
+pub use unification::generate_unification_rules;
 
 // Re-export congruence function
 pub use congruence::generate_all_explicit_congruences;
@@ -64,6 +66,7 @@ pub fn generate_ascent_source(language: &LanguageDef) -> AscentSourceOutput {
     let relations = generate_relations(language);
     let category_rules = generate_category_rules(language, None);
     let equation_rules = generate_equation_rules(language, None);
+    let unification_rules = generate_unification_rules(language, None);
     let rewrite_rules = generate_rewrite_rules(language, None);
     let custom_logic = language
         .logic
@@ -78,6 +81,8 @@ pub fn generate_ascent_source(language: &LanguageDef) -> AscentSourceOutput {
 
         #equation_rules
 
+        #unification_rules
+
         #rewrite_rules
 
         #custom_logic
@@ -87,6 +92,7 @@ pub fn generate_ascent_source(language: &LanguageDef) -> AscentSourceOutput {
     let core_raw_content = common::compute_core_categories(language).map(|core_cats| {
         let core_category_rules = generate_category_rules(language, Some(&core_cats));
         let core_equation_rules = generate_equation_rules(language, Some(&core_cats));
+        let core_unification_rules = generate_unification_rules(language, Some(&core_cats));
         let core_rewrite_rules = generate_rewrite_rules(language, Some(&core_cats));
 
         quote! {
@@ -95,6 +101,8 @@ pub fn generate_ascent_source(language: &LanguageDef) -> AscentSourceOutput {
             #core_category_rules
 
             #core_equation_rules
+
+            #core_unification_rules
 
             #core_rewrite_rules
 
@@ -119,6 +127,7 @@ pub fn generate_ascent_source(language: &LanguageDef) -> AscentSourceOutput {
         &relations,
         &category_rules,
         &equation_rules,
+        &unification_rules,
         &rewrite_rules,
         &custom_logic,
     );
@@ -142,6 +151,7 @@ fn format_ascent_source(
     relations: &TokenStream,
     category_rules: &TokenStream,
     equation_rules: &TokenStream,
+    unification_rules: &TokenStream,
     rewrite_rules: &TokenStream,
     custom_logic: &TokenStream,
 ) -> String {
@@ -157,6 +167,7 @@ fn format_ascent_source(
     let relations_str = relations.to_string();
     let category_str = category_rules.to_string();
     let equation_str = equation_rules.to_string();
+    let unification_str = unification_rules.to_string();
     let rewrite_str = rewrite_rules.to_string();
 
     output.push_str("    // Relations\n");
@@ -171,6 +182,11 @@ fn format_ascent_source(
 
     output.push_str("\n    // Equation rules\n");
     for line in split_at_top_level(&equation_str, ';') {
+        output.push_str(&print_rule(line));
+    }
+
+    output.push_str("\n    // Unification rules\n");
+    for line in split_at_top_level(&unification_str, ';') {
         output.push_str(&print_rule(line));
     }
 

--- a/macros/src/logic/relations.rs
+++ b/macros/src/logic/relations.rs
@@ -54,6 +54,17 @@ pub fn list_all_relations_for_extraction(language: &LanguageDef) -> Vec<Relation
         });
     }
 
+    // Unification/matching: unifies_proc(Proc, Proc), ...
+    for lang_type in &language.types {
+        let cat = &lang_type.name;
+        let unifies_rel = format_ident!("unifies_{}", cat.to_string().to_lowercase());
+        let ty = cat.to_string();
+        out.push(RelationForExtraction {
+            name: unifies_rel,
+            param_types: vec![ty.clone(), ty],
+        });
+    }
+
     // Fold relations (for categories that have fold rules or appear as fold-rule params)
     for lang_type in &language.types {
         let cat = &lang_type.name;
@@ -153,6 +164,12 @@ pub fn generate_relations(language: &LanguageDef) -> TokenStream {
         // Rewrite relation (typed)
         relations.push(quote! {
             relation #rw_rel(#cat, #cat);
+        });
+
+        // Unification/matching relation (typed)
+        let unifies_rel = format_ident!("unifies_{}", cat.to_string().to_lowercase());
+        relations.push(quote! {
+            relation #unifies_rel(#cat, #cat);
         });
 
         // Fold (big-step eval) relation when (1) this category has fold-mode constructors, or

--- a/macros/src/logic/rules.rs
+++ b/macros/src/logic/rules.rs
@@ -235,27 +235,20 @@ fn generate_condition_clauses(
             Condition::Unification { pattern, value } => {
                 let pat_name = pattern.to_string();
                 let val_name = value.to_string();
-                let pat_binding = lhs_clauses
-                    .bindings
-                    .get(&pat_name)
-                    .unwrap_or_else(|| panic!("Unification pattern variable '{}' not found", pat_name));
-                let val_binding = lhs_clauses
-                    .bindings
-                    .get(&val_name)
-                    .unwrap_or_else(|| panic!("Unification value variable '{}' not found", val_name));
+                let pat_binding = lhs_clauses.bindings.get(&pat_name).unwrap_or_else(|| {
+                    panic!("Unification pattern variable '{}' not found", pat_name)
+                });
+                let val_binding = lhs_clauses.bindings.get(&val_name).unwrap_or_else(|| {
+                    panic!("Unification value variable '{}' not found", val_name)
+                });
                 if pat_binding.lang_type != val_binding.lang_type {
                     panic!(
                         "Unification requires same category on both sides: {}:{} vs {}:{}",
-                        pat_name,
-                        pat_binding.lang_type,
-                        val_name,
-                        val_binding.lang_type
+                        pat_name, pat_binding.lang_type, val_name, val_binding.lang_type
                     );
                 }
-                let rel_name = format_ident!(
-                    "unifies_{}",
-                    pat_binding.lang_type.to_string().to_lowercase()
-                );
+                let rel_name =
+                    format_ident!("unifies_{}", pat_binding.lang_type.to_string().to_lowercase());
                 let pat_expr = &pat_binding.expression;
                 let val_expr = &val_binding.expression;
                 clauses.push(quote! { #rel_name(#pat_expr, #val_expr) });
@@ -348,12 +341,12 @@ fn premise_to_condition(premise: &crate::ast::language::Premise) -> Option<Condi
                 args: args.clone(),
             })
         },
-        crate::ast::language::Premise::Unification { pattern, value } => Some(
-            Condition::Unification {
+        crate::ast::language::Premise::Unification { pattern, value } => {
+            Some(Condition::Unification {
                 pattern: pattern.clone(),
                 value: value.clone(),
-            },
-        ),
+            })
+        },
         crate::ast::language::Premise::Congruence { .. } => None, // Handled separately
         crate::ast::language::Premise::ForAll { collection, param, body } => {
             Some(Condition::ForAll {

--- a/macros/src/logic/rules.rs
+++ b/macros/src/logic/rules.rs
@@ -232,6 +232,34 @@ fn generate_condition_clauses(
                     },
                 );
             },
+            Condition::Unification { pattern, value } => {
+                let pat_name = pattern.to_string();
+                let val_name = value.to_string();
+                let pat_binding = lhs_clauses
+                    .bindings
+                    .get(&pat_name)
+                    .unwrap_or_else(|| panic!("Unification pattern variable '{}' not found", pat_name));
+                let val_binding = lhs_clauses
+                    .bindings
+                    .get(&val_name)
+                    .unwrap_or_else(|| panic!("Unification value variable '{}' not found", val_name));
+                if pat_binding.lang_type != val_binding.lang_type {
+                    panic!(
+                        "Unification requires same category on both sides: {}:{} vs {}:{}",
+                        pat_name,
+                        pat_binding.lang_type,
+                        val_name,
+                        val_binding.lang_type
+                    );
+                }
+                let rel_name = format_ident!(
+                    "unifies_{}",
+                    pat_binding.lang_type.to_string().to_lowercase()
+                );
+                let pat_expr = &pat_binding.expression;
+                let val_expr = &val_binding.expression;
+                clauses.push(quote! { #rel_name(#pat_expr, #val_expr) });
+            },
         }
     }
 
@@ -320,6 +348,12 @@ fn premise_to_condition(premise: &crate::ast::language::Premise) -> Option<Condi
                 args: args.clone(),
             })
         },
+        crate::ast::language::Premise::Unification { pattern, value } => Some(
+            Condition::Unification {
+                pattern: pattern.clone(),
+                value: value.clone(),
+            },
+        ),
         crate::ast::language::Premise::Congruence { .. } => None, // Handled separately
         crate::ast::language::Premise::ForAll { collection, param, body } => {
             Some(Condition::ForAll {

--- a/macros/src/logic/unification.rs
+++ b/macros/src/logic/unification.rs
@@ -1,0 +1,48 @@
+//! Unification/matching rule generation.
+//!
+//! This module generates directional matching relations:
+//! `unifies_<cat>(pattern, value)`.
+
+use crate::ast::language::LanguageDef;
+use crate::gen::generate_var_label;
+use proc_macro2::TokenStream;
+use quote::quote;
+
+use super::common::{in_cat_filter, relation_names, CategoryFilter};
+
+/// Generate unification rules for all categories in scope.
+///
+/// Current phase implements:
+/// - eq-lifted matching: `eq_cat(p, v) => unifies_cat(p, v)`
+/// - wildcard pattern variable: `Cat::VarLabel(_)` on pattern side matches any value
+pub fn generate_unification_rules(language: &LanguageDef, cat_filter: CategoryFilter) -> TokenStream {
+    let mut rules = Vec::new();
+
+    for lang_type in &language.types {
+        let category = &lang_type.name;
+        if !in_cat_filter(category, cat_filter) {
+            continue;
+        }
+        let rn = relation_names(category);
+        let unifies_rel = quote::format_ident!("unifies_{}", rn.cat_lower);
+        let cat = rn.cat;
+        let cat_lower = rn.cat_lower;
+        let var_label = generate_var_label(&cat);
+
+        rules.push(quote! {
+            #unifies_rel(pat_u.clone(), val_u.clone()) <--
+                #cat_lower(pat_u),
+                #cat_lower(val_u),
+                if pat_u == val_u;
+        });
+        rules.push(quote! {
+            #unifies_rel(pat_u.clone(), val_u.clone()) <--
+                #cat_lower(pat_u),
+                #cat_lower(val_u),
+                if let #cat::#var_label(_) = pat_u.clone();
+        });
+    }
+
+    quote! { #(#rules)* }
+}
+

--- a/macros/src/logic/unification.rs
+++ b/macros/src/logic/unification.rs
@@ -41,6 +41,12 @@ pub fn generate_unification_rules(language: &LanguageDef, cat_filter: CategoryFi
                 #cat_lower(val_u),
                 if let #cat::#var_label(_) = pat_u.clone();
         });
+        rules.push(quote! {
+            #unifies_rel(pat_u.clone(), val_u.clone()) <--
+                #cat_lower(pat_u),
+                #cat_lower(val_u),
+                if pat_u.pattern_matches(&val_u);
+        });
     }
 
     quote! { #(#rules)* }

--- a/macros/src/logic/unification.rs
+++ b/macros/src/logic/unification.rs
@@ -15,7 +15,10 @@ use super::common::{in_cat_filter, relation_names, CategoryFilter};
 /// Current phase implements:
 /// - eq-lifted matching: `eq_cat(p, v) => unifies_cat(p, v)`
 /// - wildcard pattern variable: `Cat::VarLabel(_)` on pattern side matches any value
-pub fn generate_unification_rules(language: &LanguageDef, cat_filter: CategoryFilter) -> TokenStream {
+pub fn generate_unification_rules(
+    language: &LanguageDef,
+    cat_filter: CategoryFilter,
+) -> TokenStream {
     let mut rules = Vec::new();
 
     for lang_type in &language.types {
@@ -51,4 +54,3 @@ pub fn generate_unification_rules(language: &LanguageDef, cat_filter: CategoryFi
 
     quote! { #(#rules)* }
 }
-

--- a/readme_dev.md
+++ b/readme_dev.md
@@ -1,0 +1,317 @@
+# MeTTaIL Developer README.
+
+This file explains the project with examples.
+
+If you are new: do not worry about all the names (`Ascent`, `PraTTaIL`, `rewrite`, etc.).  
+Think of this project as a **language factory** + **language runner**:
+
+- **Build-time pipeline** = factory: turns your `language! { ... }` definition into Rust code.
+- **Runtime pipeline** = runner: takes user text and computes results using parser + rewrite/equation logic.
+
+---
+
+## Part 1: Build-time pipeline (compile `language!` DSL into Rust code)
+
+### 1) Starting point: you write a language
+
+You write code like this in files such as:
+
+- `languages/src/rhocalc.rs`
+- `languages/src/calculator.rs`
+- `languages/src/lambda.rs`
+
+Inside these files, the main input is:
+
+```rust
+language! {
+  name: MyLang,
+  types { ... },
+  terms { ... },
+  equations { ... },
+  rewrites { ... },
+  logic { ... }
+}
+```
+
+Think of this as:  
+**"Here is the grammar + math rules of my language."**
+
+---
+
+### 2) The macro entry point reads that DSL
+
+Main file:
+
+- `macros/src/lib.rs`
+
+The `language!` procedural macro does this:
+
+1. Parse DSL text into an internal AST (`LanguageDef`)
+2. Validate it
+3. Generate AST/types code
+4. Generate parser/lexer code
+5. Generate rewrite/equation logic code (Ascent rules)
+6. Generate runtime language wrapper + metadata
+
+---
+
+### 3) DSL parser stage (turn syntax into structured data)
+
+Important files:
+
+- `macros/src/ast/language.rs` (main language AST and parser)
+- `macros/src/ast/grammar.rs` (terms/grammar pieces)
+- `macros/src/ast/pattern.rs` (pattern structures)
+- `macros/src/ast/validation/validator.rs` (checks + errors)
+
+Simple idea:  
+`language!` text -> Rust structs that are easier for code generation.
+
+---
+
+### 4) Bridge to parser-generator format
+
+Important file:
+
+- `macros/src/gen/syntax/parser/prattail_bridge.rs`
+
+This converts macro AST (`LanguageDef`) into PraTTaIL format (`LanguageSpec`), which parser generation understands.
+
+PraTTaIL core types:
+
+- `prattail/src/lib.rs`
+
+Think of this as:
+
+- **Input format A** (macro world) -> **Input format B** (parser-generator world)
+
+---
+
+### 5) Parser + lexer code generation
+
+Important files:
+
+- `prattail/src/pipeline.rs` (orchestrates parser+lexer generation)
+- `prattail/src/automata/*` (regex/NFA/DFA lexer generation)
+- `prattail/src/pratt.rs` (Pratt parser generation)
+- `prattail/src/recursive.rs` (recursive-descent parts)
+- `prattail/src/trampoline.rs` (parser trampoline)
+
+Meaning in simple words:
+
+- Lexer = split text into tokens (`3`, `+`, `4`)
+- Parser = tokens -> AST tree (`Add(3, 4)`)
+
+---
+
+### 6) Rewrite/equation engine code generation (Ascent)
+
+Important files:
+
+- `macros/src/logic/mod.rs` (logic orchestrator)
+- `macros/src/logic/relations.rs`
+- `macros/src/logic/categories.rs`
+- `macros/src/logic/equations.rs`
+- `macros/src/logic/congruence.rs`
+- `macros/src/logic/rules.rs`
+
+Simple meaning:
+
+- Generate relation tables (like `rw_proc`, `eq_proc`)
+- Generate rules saying when one term rewrites to another
+- Let Ascent compute all consequences to fixpoint
+
+---
+
+### 7) Runtime glue + term operations are generated too
+
+Important files:
+
+- `macros/src/gen/mod.rs` (top-level codegen orchestrator)
+- `macros/src/gen/types/*` (AST enums)
+- `macros/src/gen/term_ops/subst.rs` (substitution)
+- `macros/src/gen/term_ops/normalize.rs` (normalization)
+- `macros/src/gen/runtime/language.rs` (implements runtime `Language` trait)
+- `macros/src/gen/runtime/metadata.rs` (metadata for REPL/help)
+
+This is the “glue” so generated language can run in the app.
+
+---
+
+### 8) Where generated files actually go
+
+Most generated Rust code is macro-expanded during compile (not manually edited files).
+
+One explicit file output exists for Blockly:
+
+- `macros/src/gen/blockly/writer.rs` writes to:
+  - `languages/src/generated/<language>-blocks.ts`
+  - `languages/src/generated/<language>-categories.ts`
+
+---
+
+### Build-time mini sample (mental model)
+
+You write:
+
+```text
+Add . a "+" b : Proc ![a + b] fold;
+```
+
+Factory creates:
+
+- Token rules for `+`
+- Parser rule for infix add
+- AST variant like `Proc::Add(...)`
+- Fold/rewrite logic so `3 + 4` can become `7`
+
+---
+
+## Part 2: Runtime pipeline (user input -> parse/evaluate/rewrite -> results)
+
+Now the generated language is used by users, mostly from REPL.
+
+### 1) Runtime entry point
+
+Important files:
+
+- `repl/src/main.rs` (CLI app start)
+- `repl/src/repl.rs` (interactive commands)
+- `languages/src/lib.rs` (language registry exports)
+
+User runs:
+
+```bash
+cargo run --bin mettail-repl
+```
+
+Then in REPL:
+
+```text
+lang rhocalc
+exec 3 + 4
+```
+
+---
+
+### 2) Core runtime interfaces
+
+Important file:
+
+- `runtime/src/language.rs`
+
+Defines:
+
+- `Term` trait
+- `Language` trait (`parse_term`, `normalize_term`, `run_ascent`, etc.)
+- `AscentResults` (all terms, rewrites, equivalences, custom relations)
+
+Generated language code implements these traits.
+
+---
+
+### 3) Runtime stages (easy version)
+
+When user enters `exec <expr>`, flow is:
+
+1. **Lex**: text -> tokens
+2. **Parse**: tokens -> AST term
+3. **Normalize**: simplify (beta-like substitutions/flattening)
+4. **Direct eval (optional fast path)**: if expression is simple ground arithmetic
+5. **Ascent fixpoint**: apply rewrite/equation logic until stable
+6. **Extract/display**: show normal forms, rewrites, eq classes
+
+---
+
+### 4) Runtime sample A: arithmetic
+
+Input:
+
+```text
+exec 3 + 4
+```
+
+Pipeline:
+
+- Lexer: `Integer(3)`, `+`, `Integer(4)`
+- Parser: `Add(CastInt(3), CastInt(4))`
+- Direct eval may short-circuit to `7`
+- Otherwise Ascent fold/rewrite derives result
+
+Output (conceptually):
+
+```text
+7
+```
+
+---
+
+### 5) Runtime sample B: process rewrite (COMM-style context)
+
+Input (rho style):
+
+```text
+{ @({}) ! ({}) | *(@({})) }
+```
+
+Pipeline:
+
+- Parse into process AST (`PPar`, `POutput`, `PDrop`, ...)
+- Ascent explores subterms and applies equations/rewrites
+- COMM/Exec/congruence-like rules derive new terms
+- Fixpoint reached when no more new rewrites/facts
+
+Output:
+
+- one or more reachable normal forms
+- optional rewrite graph / equivalence classes
+
+---
+
+### 6) Query endpoint over computed results
+
+Important files:
+
+- `query/src/lib.rs`
+- `query/src/run.rs` (re-exported by `query/src/lib.rs`)
+
+This lets you run Datalog-like queries against `AscentResults` after execution.
+
+---
+
+## Project map (one-line purpose per crate)
+
+- `languages/` -> language definitions (`language!` input)
+- `macros/` -> compiler from DSL to generated Rust code
+- `prattail/` -> parser/lexer generator engine
+- `runtime/` -> shared runtime traits/data structures
+- `repl/` -> command-line interactive frontend
+- `query/` -> query engine over runtime results
+
+---
+
+## Glossary (quick newbie terms)
+
+- **DSL**: domain-specific language (your `language! { ... }` syntax)
+- **Token**: small unit from lexer (`+`, `123`, `ident`)
+- **AST**: tree form of parsed program
+- **Rewrite**: rule that transforms one term to another (`~>`)
+- **Equation / Equivalence**: terms considered equal (`=`)
+- **Fixpoint**: keep applying rules until nothing new appears
+- **Ascent**: Rust Datalog engine used to compute rewrite/equation closures
+- **Congruence**: if subterm changes, outer term changes consistently
+
+---
+
+## TL;DR
+
+- Build-time: `language!` spec -> generated parser + AST + rewrite engine glue.
+- Runtime: user expression -> parse/normalize/rewrite -> final results.
+- If you know these files, you can navigate almost everything:
+  - `languages/src/rhocalc.rs`
+  - `macros/src/lib.rs`
+  - `macros/src/gen/mod.rs`
+  - `macros/src/logic/mod.rs`
+  - `prattail/src/lib.rs`
+  - `runtime/src/language.rs`
+  - `repl/src/repl.rs`

--- a/readme_dev.md
+++ b/readme_dev.md
@@ -1,26 +1,248 @@
-# MeTTaIL Developer README.
+# MeTTaIL Developer README
 
-This file explains the project with examples.
-
-If you are new: do not worry about all the names (`Ascent`, `PraTTaIL`, `rewrite`, etc.).  
+This file explains the project for people who need to **change** the framework or **add** languages—not only use them.  
 Think of this project as a **language factory** + **language runner**:
 
-- **Build-time pipeline** = factory: turns your `language! { ... }` definition into Rust code.
-- **Runtime pipeline** = runner: takes user text and computes results using parser + rewrite/equation logic.
+- **Build-time pipeline** = factory: turns your `language! { ... }` definition into Rust code (expanded at compile time).
+- **Runtime pipeline** = runner: takes user text and computes results using parser + normalization + optional direct eval + Ascent (rewrites/equations).
+
+---
+
+## Table of contents
+
+1. [End-to-end picture](#end-to-end-picture)
+2. [Background technologies](#background-technologies)
+3. [Part 1: Build-time pipeline](#part-1-build-time-pipeline-compile-language-dsl-into-rust-code)
+4. [Part 2: Runtime pipeline](#part-2-runtime-pipeline-user-input--parseevaluate--results)
+5. [Guide: defining a language theory](#guide-defining-a-language-theory)
+6. [Where to change what (cookbook)](#where-to-change-what-cookbook)
+7. [Adding a new language to the REPL](#adding-a-new-language-to-the-repl)
+8. [Generated artifacts on disk](#generated-artifacts-on-disk)
+9. [Project map](#project-map-one-line-purpose-per-crate)
+10. [Glossary](#glossary-quick-newbie-terms)
+
+---
+
+## End-to-end picture
+
+```mermaid
+flowchart LR
+  subgraph build["Build time (proc macro)"]
+    DSL["language! { ... }"]
+    AST["LanguageDef AST"]
+    VAL["validate_language"]
+    GEN["generate_all + generate_ascent_source + generate_language_impl"]
+    DSL --> AST --> VAL --> GEN
+  end
+  subgraph rt["Runtime (REPL / library)"]
+    TXT["User string"]
+    LEX["lex()"]
+    PAR["parse_*()"]
+    NORM["normalize_term"]
+    DEV["try_direct_eval"]
+    ASC["run_ascent → AscentResults"]
+    TXT --> LEX --> PAR --> NORM --> DEV
+    DEV -->|Some| OUT["Display"]
+    DEV -->|None| ASC --> OUT
+  end
+  GEN -.->|expands into| LEX
+  GEN -.->|expands into| PAR
+  GEN -.->|expands into| ASC
+```
+
+
+
+The macro crate (`mettail-macros`) parses and validates the DSL, then **quotes** large chunks of Rust (AST types, `Display`, substitution, parser functions, and an `ascent!` program). The `languages` crate contains modules that invoke `language!`; compiling that crate is what runs the factory.
+
+**Deeper:** Expanding `language!` happens while compiling the crate that contains it (e.g. `mettail-languages`). `cargo expand` (or `rustc` with the right flags) can show the expanded Rust for debugging. Generated names follow predictable patterns (`{Name}Language`, `parse_{Category}`, relations from `macros/src/logic/relations.rs`), so you can search the expansion for a substring from your theory when something fails late in codegen.
+
+---
+
+## Background technologies
+
+This section is for developers who know Rust but may not know **Datalog**, **trampoline parsing**, or **why** the repo is split into `macros`, `prattail`, `runtime`, and generated glue.
+
+### Rust procedural macros (`language!`), `syn`, and `quote`
+
+A **procedural macro** is a Rust function that runs at **compile time** on a stream of tokens and returns a new token stream. The `language! { ... }` block is not interpreted by the normal Rust compiler; it is handed to `macros/src/lib.rs`, which:
+
+1. Parses the inside of the macro with the **syn** crate (Rust token trees + custom `Parse` implementations for the DSL in `macros/src/ast/`).
+2. Builds an in-memory **LanguageDef** AST.
+3. Emits Rust source using **quote!** and **proc_macro2**, often as very large `TokenStream` fragments spliced together.
+
+You never “run” the macro at runtime; you **compile** a crate that uses it, and the output is ordinary Rust types and functions inlined at the call site. That is why navigation can feel odd: the “implementation” of a language often exists only **after** macro expansion.
+
+**Deeper:** `proc_macro2` lets the macro crate build tokens before they are converted to the compiler’s `proc_macro::TokenStream`. That matters because parser generator output is sometimes built as strings and then re-parsed. Errors in generated code show up as rustc errors in the **caller’s** crate, with spans sometimes pointing at the `language!` invocation; read the error chain to see which generated fragment failed.
+
+---
+
+### Ascent (Datalog-in-Rust)
+
+**[Ascent](https://github.com/s-arash/ascent)** is a library for writing **logic programs** in Rust. You declare **relations** (like database tables) and **rules** (Horn clauses) that say when new rows should exist. The engine repeatedly applies rules until **no new tuples** appear—a **least fixpoint** (in the standard stratified / safe fragment).
+
+**Conceptual vocabulary:**
+
+
+| Idea         | Meaning                                                                                          |
+| ------------ | ------------------------------------------------------------------------------------------------ |
+| Relation     | Named predicate, e.g. `rw_proc(Proc, Proc)` — “second `Proc` is a one-step rewrite of the first” |
+| Fact / tuple | One row in that relation                                                                         |
+| Rule body    | Conditions (joins, negation as supported) that must hold                                         |
+| Rule head    | New facts derived when the body holds                                                            |
+| Fixpoint     | Saturation: run rules to closure                                                                 |
+
+
+MeTTaIL **generates** an Ascent program from your `equations`, `rewrites`, and optional `logic { }` block. Category exploration, equality, and rewrite relations are all expressed in the same fixpoint so rewrites and equations can interact under congruence.
+
+**Why Ascent here?** Rewriting and equality closure are **relational**: “find all pairs `(t, t')` such that…” matches Datalog’s sweet spot (joins on subterms, indexed matching). The alternative would be hand-written graph exploration in Rust; Ascent gives a declarative layer and a mature incremental engine.
+
+**Inspection:** when you build `mettail-languages`, see `languages/src/generated/<language>-datalog.rs` for a readable dump of the generated theory (not used for compilation).
+
+**Deeper:** Stratified negation means “not” is only allowed in layers where the engine can prove the program has a unique least fixpoint. MeTTaIL-generated theories are usually positive recursions over term structure plus user rewrites; if you add negation in `logic { }`, stay within patterns Ascent accepts. Performance is dominated by join size—large languages produce many `proc(t)`/`rw_*(…)` tuples. The “core” Ascent split (when enabled) trims rules for inputs that only use a subset of categories to shorten fixpoint time.
+
+---
+
+### Datalog-style queries (`mettail-query`)
+
+The **`query/`** crate is a **small query layer on top of materialized `AscentResults`**, not a second Ascent instance. After `run_ascent`, relations and tuples are copied into `AscentResults` (including **custom relations** from your `logic { }`). A rule string is parsed, planned, and executed as joins/filters over that snapshot.
+
+If you know SQL: think “read-only analytics on tables populated by Ascent.” If you know Datalog: same spirit, with a schema inferred from `custom_relations` (`query/src/run.rs`, `query/src/data_source.rs`).
+
+**Deeper:** Queries see **stringified** term representations in relation rows (what was extracted for the REPL), not raw Rust AST pointers. That keeps the query engine language-agnostic but means you reason about **display** equality, not pointer identity. Custom relations you want to query must be listed for extraction (see relation declarations in `logic { }` and `list_all_relations_for_extraction` in `macros/src/logic/relations.rs`).
+
+---
+
+### PraTTaIL (parser + lexer codegen in this repo)
+
+**PraTTaIL** is the **MeTTaIL parser generator**: the `prattail/` crate. The name reflects the design: **Pratt** parsing (precedence climbing / binding powers for mixfix operators) combined with **generated lexers**, **recursive-descent** pieces for binders and awkward syntax, and supporting infrastructure.
+
+**Pratt parsing (very short):** Each token has **binding powers** (left/right). The parser reads a **prefix** (operand or prefix operator), then while the next operator “binds tighter” than the caller’s minimum, it consumes **infix** operators and right-hand sides. That yields correct precedence without a separate precedence table phase for every expression shape.
+
+**LanguageSpec:** The macro AST (`LanguageDef`) is **lowered** in `prattail_bridge.rs` to a flatter `LanguageSpec`: categories, syntax items, and rule inputs. PraTTaIL classifies rules (infix, cast, etc.) and runs the **pipeline** in `prattail/src/pipeline.rs` (lexer bundle → parser bundle → Rust source strings → `TokenStream`).
+
+**What PraTTaIL does *not* do:** It does not implement your rewriting semantics; it only produces **lex**, **parse_<Category>**, and helpers. Equations and `~>` are entirely in Ascent codegen (`macros/src/logic/`).
+
+**Deeper:** The bridge injects **synthetic** rules (bare identifiers as variables, collection literals, etc.) so user-written `terms { }` do not have to repeat boilerplate. Changing **only** PraTTaIL cannot add a new `language!` keyword—the DSL is defined in `macros/src/ast/`. Conversely, changing **only** `terms { }` often suffices to fix parse errors because it reshapes `LanguageSpec` and thus the whole lexer/parser product.
+
+---
+
+### Trampoline parsers (`prattail/src/trampoline.rs`)
+
+Naive **mutual recursion** (`parse_A` calls `parse_B` calls `parse_A` …) uses the **call stack**. For very deep or pathological inputs, that can **overflow the stack**.
+
+A **trampoline** parser **replaces recursion with an explicit stack of continuations** (frames) on the **heap**. The generated `parse_Cat` loops: alternate “parse a prefix / push frame” with “infix loop and unwind.” Tail-like situations avoid redundant frames. Deeply nested terms then consume heap, not fixed stack depth—see the module docs in `trampoline.rs` (“Stack-safe trampolined parser generation”).
+
+MeTTaIL’s generated parsers use this codegen path so the REPL and tests are robust on large nestings. **Recovery** variants (`*_recovering`) extend the same idea for partial error recovery.
+
+**Deeper:** Each category gets a generated `Frame_Cat` enum that records “what to do next” instead of nesting calls. The tradeoff is more generated code size and a more complex generator, but predictable memory behavior for adversarial depths. Very complex collection rules (e.g. certain ZipMapSep+binder shapes) may still use standalone recursive-descent helpers rather than the full trampoline split—see `is_simple_collection` / `has_zipmapsep` logic in `trampoline.rs`.
+
+---
+
+### Lexer generation (`prattail/src/automata`, `lexer.rs`)
+
+The lexer is **generated** from the terminals implied by the grammar (literals, keywords, punctuation). Conceptually: extract character classes and patterns, build automata, emit a function in the family `lex(input) -> Vec<(Token, Range)>`. You do not hand-write token kinds for each language; they fall out of `LanguageSpec` plus literal configuration from the DSL (`literals { ... }`, bridge).
+
+**Deeper:** Literal token definitions in `literals { }` supply **regex-like patterns** and Rust `eval` blocks; the lexer generator merges these with punctuators and keywords derived from quoted `"..."` fragments in `terms { }`. Ambiguity between two literal classes (overlapping regexes) shows up as wrong tokens first—narrow patterns or reordering may be needed. The bridge may add collection delimiters as terminals when you declare `List`/`Bag`/`Map` with `[ open, close, sep ]`-style syntax in `types { }`.
+
+---
+
+### FIRST/FOLLOW, dispatch, and prediction (`prattail/src/prediction.rs`, `dispatch.rs`)
+
+**LL-style parsing** needs to decide **which rule** to try from the **next tokens**. **FIRST** sets approximate “what token can start this construct”; **FOLLOW** sets help with error recovery and conflict reporting. PraTTaIL computes these to:
+
+- Choose between ambiguous prefix alternatives where possible  
+- Emit **warnings** for risky grammars  
+- Support optional **WFST / beam** features (feature-gated) for disambiguation
+
+You rarely edit this when adding a language; you feel it when the grammar is ambiguous and the generator warns or picks a disambiguation.
+
+**Deeper:** Cross-category dispatch (`dispatch.rs`) matters when the **same** token sequence could start multiple categories; FIRST/FOLLOW overlap diagnostics tell you “reduce/reduce” risk before runtime. The optional WFST path uses weights to rank parses—see `language!` `options { beam_width: ... }` and feature flags in the workspace `Cargo.toml`.
+
+---
+
+### `moniker` and binding-aware terms
+
+**[moniker](https://github.com/brendanzab/moniker)** is a Rust library for **names, binding, and α-equivalence**. Generated AST nodes use moniker-style variables for **bound** names (lambdas, pattern binders).
+
+MeTTaIL’s **substitution** codegen (`macros/src/gen/term_ops/subst.rs`) must **avoid capture**: substituting `N` into `^x.M` must not let free variables in `N` become accidentally bound by `x`. Moniker-style abstractions make that implementable in generated code.
+
+If you have only used `String` for variable names in interpreters, think of moniker as the difference between “rename symbols” and “respect binder scope.”
+
+**Deeper:** Generated `subst`/`open`/`close` operations follow the shape of each AST variant. If you add a binder form in `terms { }`, codegen must know how substitution walks under it—most binder shapes come from the `^x.body:[Dom -> Cod]` family already handled in `macros/src/gen/term_ops/subst.rs`. Getting this wrong shows up as “variable not captured” bugs in the REPL, not parse errors.
+
+---
+
+### Runtime glue: `Term`, `Language`, and `AscentResults`
+
+**Runtime glue** is the **interface layer** between:
+
+- **User-facing code** (REPL, tests, binaries) that wants to treat languages uniformly, and  
+- **Generated per-language code** (concrete AST enums, Ascent structs, parse functions).
+
+The shared **`runtime/`** crate defines:
+
+- **Term:** `dyn`-compatible trait (`clone_box`, `term_id`, `Display`, …) so the REPL can hold `Box<dyn Term>` without knowing `RhoCalc` vs `Calculator`.
+- **Language:** parse, normalize, `try_direct_eval`, `run_ascent`, environment APIs, type inference hooks—all implemented by **generated** `{Name}Language` in `macros/src/gen/runtime/language.rs`.
+- **AscentResults:** a **portable snapshot** (terms as display strings + IDs, rewrite edges, equivalence classes, custom relation tables) so Ascent internals do not leak into the REPL.
+
+**Why glue?** Without it, every tool would depend on every `languages::rhocalc::*` type. The traits make **one** REPL and **one** query engine possible; new languages register behind `Box<dyn Language>` (`repl/src/registry.rs`).
+
+**Deeper:** `term_id` is typically a hash of the term’s structure (see generated `impl Term`), so logically equal terms might get different IDs across runs if hashing includes allocation details—treat IDs as **session-local** handles into `AscentResults`. Multi-category languages wrap values in `{Name}TermInner` enums; `parse_term` picks the primary category or uses the language’s entry points as implemented in `generate_language_impl`.
+
+---
+
+### Blockly and visual blocks
+
+**Blockly** output (`macros/src/gen/blockly/*`) generates **TypeScript** block definitions for a visual editor. It is independent of Ascent and parsing semantics: it mirrors the language surface for another UI.
+
+**Deeper:** Blockly generation walks the same `LanguageDef` as the rest of codegen but emits `.ts` for a different consumer. Failures to write block files are usually non-fatal (`eprintln!` in `macros/src/lib.rs`). If blocks drift from real parseable syntax, fix the block generator templates in `macros/src/gen/blockly/`, not the PraTTaIL grammar, unless the surface form itself changed.
+
+---
+
+### Other names you may see
+
+
+| Name                              | What it is                                                                                                                                       |
+| --------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------ |
+| **Stratification**                | Datalog concept: negation layered so fixpoint is well-defined; Ascent enforces sensible fragments.                                               |
+| **Congruence**                    | Rules that lift rewrites/equalities **under** constructors (if inner changes, outer does too).                                                   |
+| **WFST**                          | Weighted finite-state transducer; optional feature in PraTTaIL for weighted lexing / disambiguation (`wfst` feature).                            |
+| `ascent_source!` vs `ascent!` | MeTTaIL uses both shapes: string/source forms for debugging/export; the generated language embeds a compiled `ascent!` program for `run_ascent`. |
+
 
 ---
 
 ## Part 1: Build-time pipeline (compile `language!` DSL into Rust code)
 
+### 0) Orchestrator: what runs, in what order
+
+The procedural macro entry point is `macros/src/lib.rs`. For each `language!` invocation it does, in order:
+
+1. **Parse** the token stream into `LanguageDef` (`syn` custom parser in `macros/src/ast/language.rs`).
+2. **Validate** (`macros/src/ast/validation/validator.rs` and related) — well-formedness of types, terms, patterns, binding, etc.
+3. **`generate_all`** (`macros/src/gen/mod.rs`) — AST enums, term ops, display, env, eval, **inline PraTTaIL parser** (see below).
+4. **`generate_freshness_functions`** (`macros/src/logic/rules.rs` and friends) — helpers used by generated Ascent clauses.
+5. **`generate_ascent_source`** (`macros/src/logic/mod.rs`) — relations + category + equation + rewrite rules + optional `logic { ... }` body; also writes a debug `.rs` file (see [Generated artifacts](#generated-artifacts-on-disk)).
+6. **`generate_metadata`** (`macros/src/gen/runtime/metadata.rs`) — static descriptions for REPL/help.
+7. **`generate_language_impl`** (`macros/src/gen/runtime/language.rs`) — `{Name}Term`, `{Name}Language`, `impl Language for ...`, wiring Ascent run + extraction into `AscentResults`.
+8. **Blockly** (`macros/src/gen/blockly/`) — optional TS emit to `languages/src/generated/`.
+
+Everything is concatenated into one `TokenStream` returned from the macro (except Blockly files, which are written explicitly).
+
+**Deeper:** Failures in step 3 often look like Rust type errors in generated parsers (PraTTaIL). Failures in step 5–7 often look like Ascent compile errors (“stratification”, missing relation) or mismatches between extracted relations and the `AscentResults` packer—use `*-datalog.rs` to read the actual rules the engine sees.
+
+---
+
 ### 1) Starting point: you write a language
 
-You write code like this in files such as:
+Typical locations:
 
 - `languages/src/rhocalc.rs`
 - `languages/src/calculator.rs`
 - `languages/src/lambda.rs`
+- `languages/src/ambient.rs`
 
-Inside these files, the main input is:
+Each file uses:
 
 ```rust
 language! {
@@ -29,124 +251,148 @@ language! {
   terms { ... },
   equations { ... },
   rewrites { ... },
-  logic { ... }
+  logic { ... }   // optional: extra Ascent relations/rules (verbatim)
 }
 ```
 
-Think of this as:  
-**"Here is the grammar + math rules of my language."**
+**Mental model:** you declare algebraic sorts (`types`), constructors and concrete syntax (`terms`), when two terms are equal (`equations`), and directed rewrite steps (`rewrites`). Optional `logic { }` injects raw Ascent into the same fixpoint program.
+
+Section-by-section syntax and semantics are in [Guide: defining a language theory](#guide-defining-a-language-theory).
 
 ---
 
-### 2) The macro entry point reads that DSL
+### 2) Macro entry point
 
-Main file:
 
-- `macros/src/lib.rs`
+| Item                            | Location            |
+| ------------------------------- | ------------------- |
+| `#[proc_macro] pub fn language` | `macros/src/lib.rs` |
 
-The `language!` procedural macro does this:
 
-1. Parse DSL text into an internal AST (`LanguageDef`)
-2. Validate it
-3. Generate AST/types code
-4. Generate parser/lexer code
-5. Generate rewrite/equation logic code (Ascent rules)
-6. Generate runtime language wrapper + metadata
+This is the only procedural macro exported for defining languages. Submodules: `ast`, `gen`, `logic`.
 
 ---
 
-### 3) DSL parser stage (turn syntax into structured data)
+### 3) DSL parsing and AST (`LanguageDef`)
 
-Important files:
 
-- `macros/src/ast/language.rs` (main language AST and parser)
-- `macros/src/ast/grammar.rs` (terms/grammar pieces)
-- `macros/src/ast/pattern.rs` (pattern structures)
-- `macros/src/ast/validation/validator.rs` (checks + errors)
+| Concern                                                                                 | Primary files                                                                 |
+| --------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------- |
+| Top-level `language!` parse (`LanguageDef`, `Equation`, `RewriteRule`, `LogicBlock`, …) | `macros/src/ast/language.rs`                                                  |
+| Grammar rules (`terms { ... }`)                                                         | `macros/src/ast/grammar.rs`                                                   |
+| Patterns on LHS/RHS of equations and rewrites                                           | `macros/src/ast/pattern.rs`                                                   |
+| Types, collections, native types                                                        | `macros/src/ast/types.rs` (and references from `language.rs`)                 |
+| Validation errors                                                                       | `macros/src/ast/validation/validator.rs` (+ sibling modules in `validation/`) |
 
-Simple idea:  
-`language!` text -> Rust structs that are easier for code generation.
 
----
+**Flow:** TokenStream → `LanguageDef` struct graph in memory. No code generation here—only structure.
 
-### 4) Bridge to parser-generator format
-
-Important file:
-
-- `macros/src/gen/syntax/parser/prattail_bridge.rs`
-
-This converts macro AST (`LanguageDef`) into PraTTaIL format (`LanguageSpec`), which parser generation understands.
-
-PraTTaIL core types:
-
-- `prattail/src/lib.rs`
-
-Think of this as:
-
-- **Input format A** (macro world) -> **Input format B** (parser-generator world)
+**To extend DSL syntax:** you usually add/extend `Parse` implementations and structs in `macros/src/ast/`, then teach `gen/` and `logic/` about the new constructs.
 
 ---
 
-### 5) Parser + lexer code generation
+### 4) Bridge to PraTTaIL (`LanguageSpec`)
 
-Important files:
 
-- `prattail/src/pipeline.rs` (orchestrates parser+lexer generation)
-- `prattail/src/automata/*` (regex/NFA/DFA lexer generation)
-- `prattail/src/pratt.rs` (Pratt parser generation)
-- `prattail/src/recursive.rs` (recursive-descent parts)
-- `prattail/src/trampoline.rs` (parser trampoline)
+| Item                                                | Location                                                                             |
+| --------------------------------------------------- | ------------------------------------------------------------------------------------ |
+| `LanguageDef` → `LanguageSpec` (structural mapping) | `macros/src/gen/syntax/parser/prattail_bridge.rs` (`language_def_to_spec`)           |
+| Parser codegen from spec                            | `prattail/src/lib.rs` — `pub fn generate_parser(spec: &LanguageSpec) -> TokenStream` |
+| Spec construction + classification                  | `LanguageSpec::new` and related in `prattail/`                                       |
 
-Meaning in simple words:
 
-- Lexer = split text into tokens (`3`, `+`, `4`)
-- Parser = tokens -> AST tree (`Add(3, 4)`)
+The bridge adds **synthetic** rules (variable rules, collection literals, etc.) so that identifiers and list/bag/map syntax behave consistently with the rest of codegen.
 
----
-
-### 6) Rewrite/equation engine code generation (Ascent)
-
-Important files:
-
-- `macros/src/logic/mod.rs` (logic orchestrator)
-- `macros/src/logic/relations.rs`
-- `macros/src/logic/categories.rs`
-- `macros/src/logic/equations.rs`
-- `macros/src/logic/congruence.rs`
-- `macros/src/logic/rules.rs`
-
-Simple meaning:
-
-- Generate relation tables (like `rw_proc`, `eq_proc`)
-- Generate rules saying when one term rewrites to another
-- Let Ascent compute all consequences to fixpoint
+**PraTTaIL** (`prattail/` crate) is the **lexer + Pratt/recursive-descent parser generator**. It does not know about equations or Ascent; it only consumes `LanguageSpec`.
 
 ---
 
-### 7) Runtime glue + term operations are generated too
+### 5) Parser + lexer code generation (PraTTaIL pipeline)
 
-Important files:
 
-- `macros/src/gen/mod.rs` (top-level codegen orchestrator)
-- `macros/src/gen/types/*` (AST enums)
-- `macros/src/gen/term_ops/subst.rs` (substitution)
-- `macros/src/gen/term_ops/normalize.rs` (normalization)
-- `macros/src/gen/runtime/language.rs` (implements runtime `Language` trait)
-- `macros/src/gen/runtime/metadata.rs` (metadata for REPL/help)
+| Stage                 | Role                                                                                              | Main locations                                           |
+| --------------------- | ------------------------------------------------------------------------------------------------- | -------------------------------------------------------- |
+| Orchestration         | Extract `LanguageSpec` → bundles → generate lexer string + parser string → parse to `TokenStream` | `prattail/src/pipeline.rs`                               |
+| Lexer                 | Terminals, regex/NFA/DFA-style tables, `lex()`                                                    | `prattail/src/automata/`*, `prattail/src/lexer.rs`       |
+| Pratt / mixfix        | Binding power, infix/prefix dispatch                                                              | `prattail/src/pratt.rs`, `prattail/src/binding_power.rs` |
+| Recursive descent     | Lambdas, `$name`, collection-heavy constructs                                                     | `prattail/src/recursive.rs`                              |
+| Trampoline / recovery | Stack-safe parsing, error recovery entrypoints                                                    | `prattail/src/trampoline.rs`                             |
+| Dispatch / prediction | FIRST/FOLLOW, warnings, optional WFST-related paths                                               | `prattail/src/dispatch.rs`, `prattail/src/prediction.rs` |
 
-This is the “glue” so generated language can run in the app.
+
+**Emitted in the expanded crate (per language):** functions such as `lex`, `parse_<Category>`, `parse_<Category>_recovering`, and category `impl` methods wired in `macros/src/gen/mod.rs` (`generate_prattail_category_parse_impls`).
+
+**To change how text becomes tokens:** work in `prattail` lexer paths or literal patterns (also influenced by `literals { ... }` in the DSL and bridge mapping).
+
+**To change how tokens become AST:** work in PraTTaIL parser generation, or adjust grammar rules in `terms { }` so the spec changes (often the first lever).
 
 ---
 
-### 8) Where generated files actually go
+### 6) Rewrite / equation engine codegen (Ascent)
 
-Most generated Rust code is macro-expanded during compile (not manually edited files).
 
-One explicit file output exists for Blockly:
+| Concern                                                           | Location                                                         |
+| ----------------------------------------------------------------- | ---------------------------------------------------------------- |
+| Orchestrator                                                      | `macros/src/logic/mod.rs` — `generate_ascent_source`             |
+| Relation declarations (`proc`, `eq_proc`, `rw_proc`, `fold_`*, …) | `macros/src/logic/relations.rs`                                  |
+| “Explore” category facts, deconstruct terms                       | `macros/src/logic/categories.rs`                                 |
+| Equations + congruence for `=`                                    | `macros/src/logic/equations.rs`, `macros/src/logic/congruence/*` |
+| Rewrites `~>` + congruence                                        | `macros/src/logic/rules.rs`, `macros/src/logic/congruence/*`     |
+| Shared naming / filters                                           | `macros/src/logic/common.rs`                                     |
+| Debug file writer                                                 | `macros/src/logic/writer.rs`                                     |
 
-- `macros/src/gen/blockly/writer.rs` writes to:
-  - `languages/src/generated/<language>-blocks.ts`
-  - `languages/src/generated/<language>-categories.ts`
+
+**Generated model (per category, roughly):**
+
+- **Membership:** relation `proc(Proc)`, `name(Name)`, …
+- **Equality:** `eq_proc(Proc, Proc)` (equivalence closure from equations + congruence)
+- **Rewrites:** `rw_proc(Proc, Proc)` (directed edges; user rewrites + congruence)
+- **Custom:** anything you declare in `logic { relation r(...); ... }` plus rules using those predicates
+
+Ascent runs to **fixpoint**: new tuples until saturation (subject to Ascent’s stratification/semantics).
+
+**Multi-category / SCC:** for some languages, `macros/src/logic/mod.rs` also builds a **core** rule set (`core_raw_content`) for a smaller `ascent!` struct to optimize cases where only “core” categories appear (`macros/src/logic/common.rs` — `compute_core_categories`). The runtime language impl chooses how to run this (see generated `{Name}Language`).
+
+**To change rewrite behavior:** edit `rewrites { }` / `equations { }` in the language `.rs` file. If the generator cannot express what you need, use `logic { ... }` for hand-written Ascent, or extend the codegen in `macros/src/logic/`*.
+
+---
+
+### 7) Types, term operations, runtime glue
+
+
+| Concern                                    | Location                                                  |
+| ------------------------------------------ | --------------------------------------------------------- |
+| Codegen umbrella                           | `macros/src/gen/mod.rs` — `generate_all`                  |
+| AST enums / variants                       | `macros/src/gen/types/enums.rs`                           |
+| `Display` / pretty concrete syntax         | `macros/src/gen/syntax/display.rs`                        |
+| Variable inference for parsing             | `macros/src/gen/syntax/var_inference.rs`                  |
+| Substitution (including binders)           | `macros/src/gen/term_ops/subst.rs`                        |
+| Normalization (beta, flatten, etc.)        | `macros/src/gen/term_ops/normalize.rs`, `flatten` helpers |
+| “Ground” checks                            | `macros/src/gen/term_ops/ground.rs`                       |
+| Native eval (`try_eval`, constant folding) | `macros/src/gen/native/eval.rs`                           |
+| Environments (`name = term` in REPL)       | `macros/src/gen/runtime/environment.rs`                   |
+| `Language` + `Term` impls, Ascent runner   | `macros/src/gen/runtime/language.rs`                      |
+| Metadata                                   | `macros/src/gen/runtime/metadata.rs`                      |
+| Random/exhaustive term generation (tests)  | `macros/src/gen/term_gen/*`                               |
+
+
+**To change how terms print:** `macros/src/gen/syntax/display.rs` (generator), not hand-editing output.
+
+**To change substitution or normalization:** `term_ops/`* generators.
+
+**To change direct numeric/bool evaluation:** native types in the DSL + `macros/src/gen/native/`*.
+
+---
+
+### 8) Where generated files go
+
+
+| Artifact                                           | When                                              | Path pattern                                                                                                      |
+| -------------------------------------------------- | ------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------- |
+| Rust code (types, parser, Ascent, `Language` impl) | Every build                                       | **TokenStream expansion** — not a standalone `.rs` you edit; it lives inside the expanded `language!` module.     |
+| Ascent source (debug / inspection)                 | When compiling the crate that invokes `language!` | `languages/src/generated/<languagename>-datalog.rs` (from `CARGO_MANIFEST_DIR`; see `macros/src/logic/writer.rs`) |
+| Blockly                                            | If Blockly codegen runs                           | `languages/src/generated/<language>-blocks.ts`, `...-categories.ts` (`macros/src/gen/blockly/writer.rs`)          |
+
 
 ---
 
@@ -158,34 +404,40 @@ You write:
 Add . a "+" b : Proc ![a + b] fold;
 ```
 
-Factory creates:
+The factory tends to produce (conceptually):
 
-- Token rules for `+`
-- Parser rule for infix add
-- AST variant like `Proc::Add(...)`
-- Fold/rewrite logic so `3 + 4` can become `7`
+- Lexer acceptance for `+`
+- A Pratt rule for infix `Add` with correct binding power
+- An AST variant `Proc::Add(...)` (names depend on your rule label)
+- Fold/eval wiring and Ascent relations so ground arithmetic can reduce
+
+Exact names are determined by your `terms` declaration and type names.
 
 ---
 
-## Part 2: Runtime pipeline (user input -> parse/evaluate/rewrite -> results)
-
-Now the generated language is used by users, mostly from REPL.
+## Part 2: Runtime pipeline (user input → parse / evaluate / rewrite → results)
 
 ### 1) Runtime entry point
 
-Important files:
 
-- `repl/src/main.rs` (CLI app start)
-- `repl/src/repl.rs` (interactive commands)
-- `languages/src/lib.rs` (language registry exports)
+| Item                       | Location                                                                           |
+| -------------------------- | ---------------------------------------------------------------------------------- |
+| CLI / binary               | Workspace root `Cargo.toml` — `default-run = "mettail"`, binary `repl/src/main.rs` |
+| Interactive loop, commands | `repl/src/repl.rs`                                                                 |
+| Which languages exist      | `repl/src/registry.rs` — `build_registry()`                                        |
+| Language modules           | `languages/src/lib.rs` exports `ambient`, `calculator`, `lambda`, `rhocalc`        |
 
-User runs:
+
+Run from workspace root:
 
 ```bash
-cargo run --bin mettail-repl
+cargo run
+# equivalent: cargo run --bin mettail
 ```
 
-Then in REPL:
+The package `mettail-repl` also declares the `mettail` binary (`repl/Cargo.toml`); the root crate delegates to it.
+
+In the REPL:
 
 ```text
 lang rhocalc
@@ -196,30 +448,43 @@ exec 3 + 4
 
 ### 2) Core runtime interfaces
 
-Important file:
 
-- `runtime/src/language.rs`
+| Item                                                   | Location                  |
+| ------------------------------------------------------ | ------------------------- |
+| `Term`, `Language`, `AscentResults`, `RelationData`, … | `runtime/src/language.rs` |
 
-Defines:
 
-- `Term` trait
-- `Language` trait (`parse_term`, `normalize_term`, `run_ascent`, etc.)
-- `AscentResults` (all terms, rewrites, equivalences, custom relations)
+Generated `{Name}Language` implements `Language`. Key methods:
 
-Generated language code implements these traits.
+- `parse_term` / `parse_term_for_env` — parse string to `Box<dyn Term>` (env variant avoids clearing the var cache; used when building environments).
+- `normalize_term` — generated normalization (beta / structure).
+- `try_direct_eval` — fast path for ground native evaluation when implemented.
+- `run_ascent` — runs the generated Ascent program and packs results into `AscentResults`.
+- Environment APIs — backing store for `name = term` and substitution.
 
 ---
 
-### 3) Runtime stages (easy version)
+### 3) Runtime stages (`exec` / `step`) — concrete order
 
-When user enters `exec <expr>`, flow is:
+The implementation lives in `repl/src/repl.rs`, `exec_or_step_term`. Order:
 
-1. **Lex**: text -> tokens
-2. **Parse**: tokens -> AST term
-3. **Normalize**: simplify (beta-like substitutions/flattening)
-4. **Direct eval (optional fast path)**: if expression is simple ground arithmetic
-5. **Ascent fixpoint**: apply rewrite/equation logic until stable
-6. **Extract/display**: show normal forms, rewrites, eq classes
+1. **Resolve language** from `ReplState` via `LanguageRegistry`.
+2. **Obtain AST**
+  - If input is a single identifier-like token and `get_env_term` finds a binding, use that term (avoids misparsing env names as variables).
+  - Else **`parse_term_for_env`** (still runs lexer + parser inside the generated code).
+3. **Environment substitution** — if an environment is active: `substitute_env` or `substitute_env_preserve_structure` (step mode preserves shape for interactive rewriting).
+4. **`normalize_term`** — generated beta / flatten behavior.
+5. **Direct eval (exec only)** — if `try_direct_eval` returns `Some`, the REPL short-circuits: builds `AscentResults::from_single_term` and **does not** run Ascent.
+6. **`run_ascent`** — full rewrite/equation closure; builds `AscentResults` (terms, rewrites, equivalences, `custom_relations`).
+7. **Display / state**
+  - **Exec:** prefers a **normal form** reachable from the start term via BFS on the rewrite graph (`AscentResults::normal_form_reachable_from`); may reparse displayed normal form back to `Box<dyn Term>` for state.
+  - **Step:** keeps the **initial** term as “current” and exposes `rewrites_from` for `apply N`.
+
+Auxiliary REPL behavior:
+
+- **`pre_substitute_env`** — before parse, can substitute env binding **display strings** for whole identifiers so surface syntax matches grammar (e.g. boolean literals).
+
+**Deeper:** Direct eval is a **staged** optimization: it only applies when `Language::try_direct_eval` returns `Some`, which requires native/fold support in your theory. Step mode **never** uses it so you always get a rewrite graph from the post-substitution term. Normal-form selection in exec mode is **breadth-first on rewrite IDs**, not “shortest rewrite count” or semantic cost—see `AscentResults::normal_form_reachable_from` in `runtime/src/language.rs`.
 
 ---
 
@@ -231,87 +496,345 @@ Input:
 exec 3 + 4
 ```
 
-Pipeline:
+Typical path:
 
-- Lexer: `Integer(3)`, `+`, `Integer(4)`
-- Parser: `Add(CastInt(3), CastInt(4))`
-- Direct eval may short-circuit to `7`
-- Otherwise Ascent fold/rewrite derives result
-
-Output (conceptually):
-
-```text
-7
-```
+- Lexer emits literal / operator tokens.
+- Parser builds an `Add(...)`-style AST (exact variant names depend on the language).
+- If the language defines native fold/eval, **`try_direct_eval`** may return `7` immediately.
+- Otherwise Ascent applies fold/rewrite rules until fixpoint.
 
 ---
 
-### 5) Runtime sample B: process rewrite (COMM-style context)
+### 5) Runtime sample B: process rewrite
 
-Input (rho style):
+Input (rho-style):
 
 ```text
 { @({}) ! ({}) | *(@({})) }
 ```
 
-Pipeline:
+Typical path:
 
-- Parse into process AST (`PPar`, `POutput`, `PDrop`, ...)
-- Ascent explores subterms and applies equations/rewrites
-- COMM/Exec/congruence-like rules derive new terms
-- Fixpoint reached when no more new rewrites/facts
-
-Output:
-
-- one or more reachable normal forms
-- optional rewrite graph / equivalence classes
+- Parse to process constructors (`PPar`, `POutput`, …).
+- Normalization may simplify functional structure.
+- Ascent applies `rw_*` / `eq_*` rules; congruence rules allow rewriting **inside** contexts.
+- REPL reports counts from `AscentResults` and (in exec mode) picks a displayed normal form when reachable.
 
 ---
 
-### 6) Query endpoint over computed results
+### 6) Query layer
 
-Important files:
 
-- `query/src/lib.rs`
-- `query/src/run.rs` (re-exported by `query/src/lib.rs`)
+| Item                                  | Location           |
+| ------------------------------------- | ------------------ |
+| Public API                            | `query/src/lib.rs` |
+| `run_query(rule_str, &AscentResults)` | `query/src/run.rs` |
 
-This lets you run Datalog-like queries against `AscentResults` after execution.
+
+**Pipeline:** parse rule → plan → execute against a **data source** built from `AscentResults`, including `custom_relations` (see `query/src/data_source.rs`). The schema for queries is derived from relation signatures in those results.
+
+**Use case:** after a big `run_ascent`, ask questions like “all terms reachable with property X” in a Datalog-like syntax (see REPL handling for lines containing `<--` in `repl/src/repl.rs`).
+
+**Deeper:** The query engine does not re-execute your language’s Ascent rules; it only reads **what was already materialized** into `custom_relations` and the standard rewrite/equality views exposed in `AscentResults`. If a relation is missing from results, fix extraction in `generate_language_impl` / relation listing, or ensure your `logic { }` rules actually populate those tuples.
+
+---
+
+## Guide: defining a language theory
+
+This guide walks through **each block** of a `language!` definition: the syntax you write, what it **means** semantically, what **goal** it serves, and how the **factory** uses it. The canonical parse order of blocks is fixed (`macros/src/ast/language.rs`, `impl Parse for LanguageDef`).
+
+### Top-level shape and block order
+
+```text
+language! {
+    name: YourLanguage,
+    options { ... },       /* optional */
+    types { ... },
+    literals { ... },      /* optional; requires types before it */
+    terms { ... },
+    equations { ... },
+    rewrites { ... },
+    logic { ... },         /* optional */
+}
+```
+
+Comma separation between major clauses follows normal Rust macro parsing (trailing commas are fine where Rust allows). If you omit optional blocks, the parser still expects `types` and typically `terms`; empty `equations { }` / `rewrites { }` are valid when you only need parsing.
+
+**How it fits together:** `types` fixes the sorting discipline (what kinds of AST nodes exist). `terms` determines **concrete syntax** and **constructors** (and injects native/code blocks for evaluation). `literals` customizes lexer tokens for those types. `equations` and `rewrites` define **Ascent’s** equality and directed steps on those ASTs. `logic` extends Ascent with your own relations when codegen is not enough.
+
+---
+
+### `name:` — language identifier
+
+**Syntax:** `name: Ident,`
+
+**Semantics:** Becomes the Rust identifier prefix for generated items: `YourLanguage`, `YourLanguageLanguage`, `parse_Proc`, etc., and the string returned by `Language::name()`.
+
+**Goal:** Stable human- and machine-readable label; used in REPL prompts and metadata.
+
+**How it works:** Referenced throughout `macros/src/gen/*` and `macros/src/logic/*` for naming; Ascent debug output is written as `languages/src/generated/<lowercase>-datalog.rs`.
+
+---
+
+### `options { }` — rare configuration
+
+**Syntax:** `options { key: value, ... }` where `value` is a float, integer, bool, string literal, or keyword identifier (`none`, `auto`, … depending on key).
+
+**Semantics:** Key–value map (`AttributeValue` in `macros/src/ast/language.rs`). Known keys include PraTTaIL-related settings such as **`beam_width`** (float or `none` / `disabled` / `auto`) and **`log_semiring_model_path`** (string); **`dispatch`** controls dispatch strategy when using WFST-related features.
+
+**Goal:** Tune parser disambiguation without forking the DSL; most small languages omit `options`.
+
+**How it works:** Parsed into `LanguageDef.options` and read by codegen paths that care (e.g. PraTTaIL when the `wfst` feature is on). Unused keys may be accepted with less validation—extend validation if you add a new option.
+
+---
+
+### `types { }` — sorts, native payload types, collections
+
+**Syntax (examples):**
+
+```text
+types {
+    Proc                                    /* algebraic sort, carried in AST enum */
+    ![i32] as Int                           /* sort Int with runtime payload i32 */
+    ![Vec<Proc>] as List                    /* collection sort; element type in Vec<...> */
+    Bag [ "{", "}", "|" ]                   /* multiset with delimiter triple for surface syntax */
+}
+```
+
+- Plain `Name;` declares a **category** with no built-in Rust payload (pure algebraic).
+- `![RustType] as Category` declares that AST values of `Category` carry a **native** `RustType` (integers, `bool`, `str`, custom Newtypes, etc.). This enables **`try_direct_eval`**, `fold`/`step` codegen, and native printers.
+- **`List` / `Bag` / `Map`** entries can use bracket delimiter specs; internally bound to `CollectionCategory` (`macros/src/ast/language.rs`). The **native** type is usually `Vec<Elem>`, `HashBag<Elem>`, `HashMap<K,V>`.
+
+**Semantics:** Defines the set of generated **enum variants per category**, variable forms (`IVar`, `PVar`, … from naming conventions), and what PraTTaIL treats as a **category** in `LanguageSpec`.
+
+**Goal:** Separates “what kinds of things exist in my language” from “how to parse them” (`terms`).
+
+**How it works:** `macros/src/gen/types/enums.rs` emits the AST; `prattail_bridge.rs` emits `CategorySpec` rows (primary category, `has_var`, optional `native_type` string); `macros/src/logic/relations.rs` emits `category(...)`, `eq_*`, `rw_*`, and optionally `fold_*` relations.
+
+---
+
+### `literals { }` — lexer classes for literals
+
+**Syntax:**
+
+```text
+literals {
+    Int {
+        pattern: r"[0-9]+";
+        eval: ![ { /* expression using `text: &str` */ } ]
+    }
+}
+```
+
+**Semantics:** Each entry names a **type** (must correspond to a `types` entry), provides a **regex-style pattern** string for the generated lexer, and an **`eval`** block `![ ... ]` that returns `Result<NativeValue, ()>` (or compatible) given implicit `text: &str`.
+
+**Goal:** Let you control how numeric/string/bool literals look **without** encoding every digit as a separate `terms` rule.
+
+**How it works:** Wired into PraTTaIL literal patterns (`LiteralSpec` → lexer codegen). See `languages/src/calculator.rs` for rich examples (BigInt, rationals, floats, strings).
+
+---
+
+### `terms { }` — constructors, grammar, evaluation hooks
+
+MeTTaIL supports two styles (see `GrammarRule` in `macros/src/ast/grammar.rs`):
+
+1. **Judgement style (preferred):**  
+   `Label . context |- concrete_syntax : Category [rust_code] [eval_mode] [right] [prefix(N)] ;`
+2. **Legacy BNFC style:**  
+   `Label . Category ::= item item ... ;`
+
+#### Judgement rule anatomy
+
+- **`Label`** — constructor / variant name (becomes `Category::Label(...)` in the generated enum).
+- **Context** — comma-separated binders, e.g. `n:Name, ^x.p:[Name -> Proc]`
+  - Simple `x:Ty` — subtree parameter.
+  - **`^x.p:[Dom -> Cod]`** — higher-order binder: `x` bound in `p` (generates moniker `Lam`/`Apply` plumbing).
+  - **`^[xs].p:[Dom* -> Cod]`** — multi-binder form.
+- **`|-`** — separates metasyntax (binders) from object syntax.
+- **Concrete syntax** — quoted literals (`"+"`), parameter references (`a`, `p`), binders (`<Name>` in old style; in judgements abstraction is in context), collections with `ps.*sep("|")`-flavored metasyntax (`#sep`, `#map`, `#zip`, `#opt` in `SyntaxExpr`).
+- **`: Category`** — sort of the whole form.
+- **Optional `![expr]`** — Rust expression constructing the native or algebraic value (often refers to parameters by name). Used for **constant folding** and injections.
+- **Optional `fold` or `step`** (`EvalMode` in `macros/src/ast/types.rs`)
+  - **`fold`** — eager reduction via generated `![...]` when subterms are values; also ties into Ascent **`fold_*`** relations when codegen detects fold-shaped rules.
+  - **`step`** — mark rules for **congruence / small-step** plumbing (useful when you must not collapse everything to a single big_fold).
+- **`right`** — right-associative infix for this rule.
+- **`prefix(N)`** — explicit binding power for prefix operators.
+
+**Semantics:** Each rule contributes **both** a parser production **and** an AST constructor. Infix/nfix rules get Pratt binding powers from PraTTaIL classification.
+
+**Goal:** Single source of truth for “what the program looks like” and “what its tree is.”
+
+**How it works:** `prattail_bridge` lowers rules to `RuleSpecInput`; PraTTaIL emits parse functions; `macros/src/gen/types` + `display` + `subst` + `normalize` read the same `GrammarRule` list. Native `![...]` blocks feed **`macros/src/gen/native/eval.rs`** and Ascent fold generation.
+
+---
+
+### `equations { }` — undirected equality
+
+**Syntax (judgement style):**
+
+```text
+RuleName . optional_type_context | optional_premises |- lhs_pattern = rhs_pattern ;
+```
+
+- **Premises** (after `|`) can include **freshness** `x # P` (“`x` not free in `P`”), **relation queries**, and **`forall`**-style iteration over collections (`Premise` in `macros/src/ast/language.rs`).
+- **Patterns** on LHS/RHS use the same pattern language as rewrites (`macros/src/ast/pattern.rs`).
+
+**Semantics:** **Equivalence** up to congruence: generated **`eq_<category>`** facts in Ascent, closed under structural rules.
+
+**Goal:** Algebraic laws, type identifications, undefined behavior collapse—anything **symmetric** in intent.
+
+**How it works:** `macros/src/logic/equations.rs` + `congruence` emit Ascent rules that populate `eq_*` and interact with category exploration (`categories.rs`). Equations do **not** add directed `rw_*` edges unless a rewrite also exists.
+
+---
+
+### `rewrites { }` — directed reduction
+
+**Syntax:**
+
+```text
+RuleName . optional_type_context | optional_premises |- lhs_pattern ~> rhs_pattern ;
+```
+
+- **Congruence-style conditional rewrites:** premises may include **`S ~> T`** (if inner rewrites, outer can rewrite)—see `Premise::Congruence` and examples like `if S ~> T then (...)` in `README.md` / `rhocalc.rs`.
+
+**Semantics:** **Directed** edges in **`rw_<category>`**. Congruence lifts rewrites under contexts (parsing / pattern shape determines which congruence rules are generated).
+
+**Goal:** Operational semantics, reduction, commutations, COMM-like rules in the ρ-calculus style.
+
+**How it works:** `macros/src/logic/rules.rs` + `congruence` generate base and lifted rules. Freshness side conditions become helper calls from `generate_freshness_functions`.
+
+---
+
+### `logic { }` — hand-written Ascent
+
+**Syntax:** Inside the braces you write **Ascent** surface syntax (relations + rules) as the engine expects, plus optional **relation declarations** parsed by MeTTaIL for extraction metadata:
+
+```text
+logic { 
+    relation path(Proc, Proc);
+    path(x, y) <-- rw_proc(x, y);
+    path(x, z) <-- rw_proc(x, y), path(y, z);
+}
+```
+
+**Semantics:** Extends the **same** fixpoint program as generated equations/rewrites. Use when you need custom transitive closure, instrumentation, or relations that do not map cleanly to `~>` / `=`.
+
+**Goal:** Escape hatch without patching `macros/src/logic/*`.
+
+**How it works:** `RelationDecl` tuples feed `list_all_relations_for_extraction`; verbatim rule bodies are spliced into `generate_ascent_source` (`macros/src/logic/mod.rs`). Relations you query in `mettail-query` must appear in the extracted snapshot—check `macros/src/gen/runtime/language.rs` extraction if a relation is missing client-side.
+
+---
+
+### Minimal skeleton (new language starting point)
+
+```rust
+use mettail_macros::language;
+
+language! {
+    name: Tiny,
+    types {
+        ![i32] as Int
+        Expr
+    },
+    literals {
+        Int {
+            pattern: r"[0-9]+";
+            eval: ![ { text.parse::<i32>().map_err(|_| ()) } ]
+        }
+    },
+    terms {
+        Lit . n:Int |- n : Expr ;
+        Add . a:Expr, b:Expr |- a "+" b : Expr ;
+    },
+    equations { },
+    rewrites { },
+}
+```
+
+Grow this toward full examples: `languages/src/calculator.rs` (many sorts, `fold`/`step`, rationals) and `languages/src/rhocalc.rs` (binding, collections, rich rewrite/equation theory).
+
+---
+
+## Where to change what (cookbook)
+
+
+| Goal                                    | First place to look                                | Notes                                                                                           |
+| --------------------------------------- | -------------------------------------------------- | ----------------------------------------------------------------------------------------------- |
+| Add / rename sorts                      | `types { }` in language file                       | Drives AST enums, relations, and parser entry points.                                           |
+| Add syntax for a construct              | `terms { }`                                        | Changes both AST and PraTTaIL spec via the bridge.                                              |
+| Change precedence / fixity              | Grammar in `terms { }` and PraTTaIL classification | If the grammar is ambiguous or wrong classified, `prattail/src/*.rs` (binding power, dispatch). |
+| Change pretty-printing                  | `macros/src/gen/syntax/display.rs`                 | Generated `Display` for variants.                                                               |
+| Change capture-avoiding substitution    | `macros/src/gen/term_ops/subst.rs`                 | Works with `moniker`-style binding in generated code.                                           |
+| Change normalization / beta             | `macros/src/gen/term_ops/normalize.rs`             | Wired into `Language::normalize_term`.                                                          |
+| Add equality reasoning                  | `equations { }`                                    | codegen → `macros/src/logic/equations.rs` output.                                               |
+| Add rewrite rules                       | `rewrites { }`                                     | codegen → `macros/src/logic/rules.rs` + congruence.                                             |
+| Add custom relations / rules            | `logic { ... }` in language file                   | Verbatim Ascent mixed into generated program; declare relations for extraction if needed.       |
+| Change how Ascent results are collected | `macros/src/gen/runtime/language.rs`               | Extraction from Ascent relations into `AscentResults`.                                          |
+| REPL commands / UX                      | `repl/src/repl.rs`                                 | Orchestration only; keep language-agnostic.                                                     |
+| Register a new language in CLI          | `repl/src/registry.rs`                             | Insert `Box::new(YourLanguage)`.                                                                |
+
+
+---
+
+## Adding a new language to the REPL
+
+For what each block in `language!` does, see [Guide: defining a language theory](#guide-defining-a-language-theory).
+
+1. Create `languages/src/my_lang.rs` with `language! { name: MyLang, ... }`.
+2. Add `pub mod my_lang;` to `languages/src/lib.rs` and re-export any `*_source` or types you need (follow existing modules).
+3. Register **`MyLangLanguage`** in `repl/src/registry.rs` (`build_registry`).
+4. Run `cargo build -p mettail-languages` and inspect `languages/src/generated/my_lang-datalog.rs` if Ascent behavior is wrong.
+5. Optional: add example snippets under `repl/src/examples/` and wire them in the examples module if you use that pattern.
+
+If something fails at compile time, errors usually point at the macro span in your `language!` block; for parser issues, compare generated parse functions conceptually with `LanguageSpec` from the bridge.
+
+---
+
+## Generated artifacts on disk
+
+- **`languages/src/generated/<name>-datalog.rs`** — pretty-printed Ascent program for inspection (not compiled). Regenerated when the language crate is built; **do not edit** for real fixes—change the `language!` or the codegen.
+- **Blockly `.ts`** — visual block exports when that path runs successfully.
 
 ---
 
 ## Project map (one-line purpose per crate)
 
-- `languages/` -> language definitions (`language!` input)
-- `macros/` -> compiler from DSL to generated Rust code
-- `prattail/` -> parser/lexer generator engine
-- `runtime/` -> shared runtime traits/data structures
-- `repl/` -> command-line interactive frontend
-- `query/` -> query engine over runtime results
+
+| Crate                   | Role                                                                      |
+| ----------------------- | ------------------------------------------------------------------------- |
+| `languages/`            | Concrete `language!` theories and generated artifacts folder              |
+| `macros/`               | Compiler from DSL to expanded Rust (AST, parser, Ascent, `Language` impl) |
+| `prattail/`             | Lexer + parser generator used by `macros`                                 |
+| `runtime/`              | Shared traits and `AscentResults` shape                                   |
+| `repl/`                 | CLI / `mettail` binary frontend                                           |
+| `query/`                | Query engine over `AscentResults`                                         |
+| `ascent_syntax_export/` | Supporting tooling for Ascent-related workflows (see crate docs)          |
+
 
 ---
 
 ## Glossary (quick newbie terms)
 
-- **DSL**: domain-specific language (your `language! { ... }` syntax)
-- **Token**: small unit from lexer (`+`, `123`, `ident`)
-- **AST**: tree form of parsed program
-- **Rewrite**: rule that transforms one term to another (`~>`)
-- **Equation / Equivalence**: terms considered equal (`=`)
-- **Fixpoint**: keep applying rules until nothing new appears
-- **Ascent**: Rust Datalog engine used to compute rewrite/equation closures
-- **Congruence**: if subterm changes, outer term changes consistently
+Longer treatment of Ascent, PraTTaIL, trampoline parsing, runtime traits, and related ideas: [Background technologies](#background-technologies).  
+Syntax and semantics of each `language!` block (`types`, `terms`, `equations`, …): [Guide: defining a language theory](#guide-defining-a-language-theory).
+
+- **DSL:** the `language! { ... }` syntax you author.
+- **Token:** lexer output (`+`, integer literal, identifier, …).
+- **AST:** typed tree of language terms (generated enums).
+- **Rewrite:** directed step `~>` between terms.
+- **Equation / equivalence:** undirected equality `=` generating `eq_`* facts + congruence.
+- **Fixpoint:** repeat rule application until no new tuples.
+- **Ascent:** Rust Datalog engine; generated code uses `ascent!` / `ascent_source!`.
+- **Congruence:** if a subterm rewrites (or equals), the whole term may rewrite (or equal) consistently.
+- **PraTTaIL:** **Pratt** + **Ta**il-recursive / **I**nline **L**exer-style pipeline — this project’s parser generator crate name.
 
 ---
 
 ## TL;DR
 
-- Build-time: `language!` spec -> generated parser + AST + rewrite engine glue.
-- Runtime: user expression -> parse/normalize/rewrite -> final results.
-- If you know these files, you can navigate almost everything:
-  - `languages/src/rhocalc.rs`
-  - `macros/src/lib.rs`
-  - `macros/src/gen/mod.rs`
-  - `macros/src/logic/mod.rs`
-  - `prattail/src/lib.rs`
-  - `runtime/src/language.rs`
-  - `repl/src/repl.rs`
+- **Build-time:** `language!` → validate → `generate_all` (types, ops, PraTTaIL parser) + `generate_ascent_source` (Datalog) + `generate_language_impl` (runner).
+- **Runtime:** parse → env subst → normalize → optional `try_direct_eval` → else `run_ascent` → `AscentResults` → REPL picks display / stepping.
+- **Tech context:** [Background technologies](#background-technologies) explains Ascent (Datalog), PraTTaIL, trampolines, `moniker`, query layer, and runtime glue.
+- **Defining a theory:** [Guide: defining a language theory](#guide-defining-a-language-theory) documents each DSL block (`types`, `terms`, `equations`, `rewrites`, `logic`, …).
+- **Navigation anchors:** `languages/src/<your_lang>.rs`, `macros/src/lib.rs`, `macros/src/gen/mod.rs`, `macros/src/logic/mod.rs`, `macros/src/gen/syntax/parser/prattail_bridge.rs`, `prattail/src/pipeline.rs`, `runtime/src/language.rs`, `repl/src/repl.rs`, `repl/src/registry.rs`.
+

--- a/repl/src/examples/rhocalc.rs
+++ b/repl/src/examples/rhocalc.rs
@@ -284,13 +284,13 @@ pub static SELF_COMM: Example = Example {
 //=============================================================================
 // MULTI-COMMUNICATION PATTERNS
 //=============================================================================
-// These examples use the join pattern: (n1?x, n2?y).{body}
+// These examples use the join pattern: (x <- n1, y <- n2){body}
 // which receives from multiple channels atomically before proceeding.
 
 pub static JOIN_BASIC: Example = Example {
     name: "join_basic",
     description: "Basic join: wait for two channels before proceeding",
-    source: "{(a?x, b?y).{result!({*(x) | *(y)})} | a!(p) | b!(q)}",
+    source: "{(x <- a, y <- b){result!({*(x) | *(y)})} | a!(p) | b!(q)}",
     category: ExampleCategory::MultiComm,
     language: LanguageName::RhoCalculus,
 };
@@ -299,7 +299,7 @@ pub static JOIN_BARRIER: Example = Example {
     name: "join_barrier",
     description: "Join barrier: cleaner than nested for-loops",
     source: "{
-        (ready1?x, ready2?y, ready3?z).{go!({*(x) | *(y) | *(z)})} |
+        (x <- ready1, y <- ready2, z <- ready3){go!({*(x) | *(y) | *(z)})} |
         ready1!(a) | ready2!(b) | ready3!(c)
     }",
     category: ExampleCategory::MultiComm,
@@ -309,7 +309,7 @@ pub static JOIN_BARRIER: Example = Example {
 pub static JOIN_SAME_CHANNEL: Example = Example {
     name: "join_same_channel",
     description: "Join on same channel: consume two distinct messages atomically",
-    source: "{(c?x, c?y).{{*(x) | *(y)}} | c!(a) | c!(b)}",
+    source: "{(x <- c, y <- c){{*(x) | *(y)}} | c!(a) | c!(b)}",
     category: ExampleCategory::MultiComm,
     language: LanguageName::RhoCalculus,
 };
@@ -318,7 +318,7 @@ pub static ATOMIC_PAIR: Example = Example {
     name: "atomic_pair",
     description: "Atomic pair receive: prevents partial consumption",
     source: "{
-        (key?k, value?v).{store!({*(k) | *(v)})} |
+        (k <- key, v <- value){store!({*(k) | *(v)})} |
         key!(name) | value!(data)
     }",
     category: ExampleCategory::MultiComm,
@@ -330,8 +330,8 @@ pub static SCATTER_GATHER: Example = Example {
     description: "Scatter-gather: broadcast request, collect all responses",
     source: "{
         req!(query) |
-        (req?q).{{resp1!(*(q)) | resp2!(*(q))}} |
-        (resp1?r1, resp2?r2).{result!({*(r1) | *(r2)})}
+        (q <- req){{resp1!(*(q)) | resp2!(*(q))}} |
+        (r1 <- resp1, r2 <- resp2){result!({*(r1) | *(r2)})}
     }",
     category: ExampleCategory::MultiComm,
     language: LanguageName::RhoCalculus,
@@ -342,7 +342,7 @@ pub static RESOURCE_LOCK: Example = Example {
     description: "Atomic resource acquisition: acquire both forks or neither",
     source: "{
         fork1!(f1) | fork2!(f2) |
-        (fork1?a, fork2?b).{eating!({*(a) | *(b)})}
+        (a <- fork1, b <- fork2){eating!({*(a) | *(b)})}
     }",
     category: ExampleCategory::MultiComm,
     language: LanguageName::RhoCalculus,
@@ -352,9 +352,9 @@ pub static RENDEZVOUS: Example = Example {
     name: "rendezvous",
     description: "Rendezvous: two parties meet and exchange simultaneously",
     source: "{
-        (alice_out?a, bob_out?b).{{alice_in!(*(b)) | bob_in!(*(a))}} |
+        (a <- alice_out, b <- bob_out){{alice_in!(*(b)) | bob_in!(*(a))}} |
         alice_out!(gift_a) | bob_out!(gift_b) |
-        (alice_in?x).{got_a!(*(x))} | (bob_in?y).{got_b!(*(y))}
+        (x <- alice_in){got_a!(*(x))} | (y <- bob_in){got_b!(*(y))}
     }",
     category: ExampleCategory::MultiComm,
     language: LanguageName::RhoCalculus,
@@ -364,7 +364,7 @@ pub static CORRELATION: Example = Example {
     name: "correlation",
     description: "Correlated receive: match request with its response by correlation ID",
     source: "{
-        (request?id, response?data).{matched!({*(id) | *(data)})} |
+        (id <- request, data <- response){matched!({*(id) | *(data)})} |
         request!(txn42) | response!(result42)
     }",
     category: ExampleCategory::MultiComm,
@@ -375,7 +375,7 @@ pub static MULTI_PARTY_SYNC: Example = Example {
     name: "multi_party_sync",
     description: "Multi-party synchronization: all four parties must contribute",
     source: "{
-        (p1?a, p2?b, p3?c, p4?d).{consensus!({*(a) | *(b) | *(c) | *(d)})} |
+        (a <- p1, b <- p2, c <- p3, d <- p4){consensus!({*(a) | *(b) | *(c) | *(d)})} |
         p1!(vote1) | p2!(vote2) | p3!(vote3) | p4!(vote4)
     }",
     category: ExampleCategory::MultiComm,

--- a/repl/src/examples/rhocalc.rs
+++ b/repl/src/examples/rhocalc.rs
@@ -48,7 +48,7 @@ pub fn all() -> Vec<&'static Example> {
 pub static SIMPLE_COMM: Example = Example {
     name: "simple_comm",
     description: "Basic communication: single channel, immediate communication",
-    source: "{a!(0) | for(a->x){*(x)}}",
+    source: "{a!(0) | for(x <- a){*(x)}}",
     category: ExampleCategory::Simple,
     language: LanguageName::RhoCalculus,
 };
@@ -56,7 +56,7 @@ pub static SIMPLE_COMM: Example = Example {
 pub static SEQUENTIAL: Example = Example {
     name: "sequential",
     description: "Two independent channels communicating in parallel",
-    source: "{a!(0) | for(a->x){*(x)} | b!(0) | for(b->y){*(y)}}",
+    source: "{a!(0) | for(x <- a){*(x)} | b!(0) | for(y <- b){*(y)}}",
     category: ExampleCategory::Simple,
     language: LanguageName::RhoCalculus,
 };
@@ -64,7 +64,7 @@ pub static SEQUENTIAL: Example = Example {
 pub static REFLECTION: Example = Example {
     name: "reflection",
     description: "Quote/drop cycle demonstrating reflection",
-    source: "{for(@(0)->x){*x} | @(0)!(0)}",
+    source: "{for(x <- @(0)){*x} | @(0)!(0)}",
     category: ExampleCategory::Simple,
     language: LanguageName::RhoCalculus,
 };
@@ -76,7 +76,7 @@ pub static REFLECTION: Example = Example {
 pub static CHOICE: Example = Example {
     name: "choice",
     description: "Non-deterministic choice: multiple listeners on same channel",
-    source: "{a!(0) | for(a->x){x!(0)} | for(a->y){y!(0)}}",
+    source: "{a!(0) | for(x <- a){x!(0)} | for(y <- a){y!(0)}}",
     category: ExampleCategory::Branching,
     language: LanguageName::RhoCalculus,
 };
@@ -84,7 +84,7 @@ pub static CHOICE: Example = Example {
 pub static RACE: Example = Example {
     name: "race",
     description: "Race condition: multiple senders, one listener",
-    source: "{a!(0) | a!(1) | for(a->x){*(x)}}",
+    source: "{a!(0) | a!(1) | for(x <- a){*(x)}}",
     category: ExampleCategory::Branching,
     language: LanguageName::RhoCalculus,
 };
@@ -96,7 +96,7 @@ pub static RACE: Example = Example {
 pub static FORWARD: Example = Example {
     name: "forward",
     description: "Relay messages between channels (forwarder pattern)",
-    source: "{a!(0) | for(a->x){b!(*(x))} | for(b->y){*(y)}}",
+    source: "{a!(0) | for(x <- a){b!(*(x))} | for(y <- b){*(y)}}",
     category: ExampleCategory::Complex,
     language: LanguageName::RhoCalculus,
 };
@@ -104,7 +104,7 @@ pub static FORWARD: Example = Example {
 pub static CIRCULAR: Example = Example {
     name: "circular",
     description: "Circular communication (infinite loop, no normal form)",
-    source: "{a!(0) | for(a->x){b!(*(x))} | for(b->y){a!(*(y))}}",
+    source: "{a!(0) | for(x <- a){b!(*(x))} | for(y <- b){a!(*(y))}}",
     category: ExampleCategory::Complex,
     language: LanguageName::RhoCalculus,
 };
@@ -112,7 +112,7 @@ pub static CIRCULAR: Example = Example {
 pub static HANDSHAKE: Example = Example {
     name: "handshake",
     description: "Three-way handshake protocol",
-    source: "{a!(0) | for(a->x){{b!(*(x)) | for(c->z){*(z)}}} | for(b->y){c!(*(y))}}",
+    source: "{a!(0) | for(x <- a){{b!(*(x)) | for(z <- c){*(z)}}} | for(y <- b){c!(*(y))}}",
     category: ExampleCategory::Complex,
     language: LanguageName::RhoCalculus,
 };
@@ -126,12 +126,12 @@ pub static MULTI_PATH: Example = Example {
     description: "Multiple concurrent communications with dependencies (50 terms, 66 rewrites)",
     source: "{
         a!(0) |
-        for(a->x0){ {x0!(0) | for(b->y1){y1!(*(a))}} } |
+        for(x0 <- a){ {x0!(0) | for(y1 <- b){y1!(*(a))}} } |
         b!(0) |
-        for(b->x1){a!(*(b))} |
+        for(x1 <- b){a!(*(b))} |
         c!(0) |
-        for(c->x2){x2!(0)} |
-        for(@(0)->y0){*(y0)}
+        for(x2 <- c){x2!(0)} |
+        for(y0 <- @(0)){*(y0)}
     }",
     category: ExampleCategory::Parallel,
     language: LanguageName::RhoCalculus,
@@ -141,10 +141,10 @@ pub static PARALLEL: Example = Example {
     name: "parallel",
     description: "Four independent parallel processes (many execution orders)",
     source: "{
-        a!(0) | for(a->x){*(x)  } |
-        b!(0) | for(b->y){*(y)  } |
-        c!(0) | for(c->z){*(z)  } |
-        d!(0) | for(d->w){*(w)  }
+        a!(0) | for(x <- a){*(x)  } |
+        b!(0) | for(y <- b){*(y)  } |
+        c!(0) | for(z <- c){*(z)  } |
+        d!(0) | for(w <- d){*(w)  }
     }",
     category: ExampleCategory::Parallel,
     language: LanguageName::RhoCalculus,
@@ -153,7 +153,7 @@ pub static PARALLEL: Example = Example {
 pub static BARRIER: Example = Example {
     name: "barrier",
     description: "Barrier synchronization: wait for all inputs",
-    source: "{a!(0) | b!(0) | for(a->x){for(b->y){{*(x) | *(y)}}}}",
+    source: "{a!(0) | b!(0) | for(x <- a){for(y <- b){{*(x) | *(y)}}}}",
     category: ExampleCategory::Parallel,
     language: LanguageName::RhoCalculus,
 };
@@ -165,7 +165,7 @@ pub static BARRIER: Example = Example {
 pub static SPAWN: Example = Example {
     name: "spawn",
     description: "Recursive spawning: process creates new processes",
-    source: "{a!(0) | for(a->x){{a!(*(x)) | for(a->y){*(y)}}}",
+    source: "{a!(0) | for(x <- a){{a!(*(x)) | for(y <- a){*(y)}}}",
     category: ExampleCategory::Advanced,
     language: LanguageName::RhoCalculus,
 };
@@ -173,7 +173,7 @@ pub static SPAWN: Example = Example {
 pub static FRESH_NAMES: Example = Example {
     name: "fresh_names",
     description: "Name generation via bound variables (capability passing)",
-    source: "{for(new->chan){{chan!(0) | for(chan->x){*(x)}}} | new!(@(0))}",
+    source: "{for(chan <- new){{chan!(0) | for(x <- chan){*(x)}}} | new!(@(0))}",
     category: ExampleCategory::Advanced,
     language: LanguageName::RhoCalculus,
 };
@@ -181,7 +181,7 @@ pub static FRESH_NAMES: Example = Example {
 pub static CONTRACT: Example = Example {
     name: "contract",
     description: "Contract net: broadcast request, collect responses",
-    source: "{req!(0) | for(req->x){{resp1!(*(x)) | resp2!(*(x))}} | for(resp1->a){*(a)  } | for(resp2->b){*(b)  }}",
+    source: "{req!(0) | for(x <- req){{resp1!(*(x)) | resp2!(*(x))}} | for(a <- resp1){*(a)  } | for(b <- resp2){*(b)  }}",
     category: ExampleCategory::Advanced,
     language: LanguageName::RhoCalculus,
 };
@@ -189,7 +189,7 @@ pub static CONTRACT: Example = Example {
 pub static DEADLOCK: Example = Example {
     name: "deadlock",
     description: "Deadlock: circular dependency, no progress possible",
-    source: "{for(a->x){for(b->y){{*(x) | *(y)}}} | for(b->z){a!(z)}}",
+    source: "{for(x <- a){for(y <- b){{*(x) | *(y)}}} | for(z <- b){a!(z)}}",
     category: ExampleCategory::Advanced,
     language: LanguageName::RhoCalculus,
 };
@@ -199,8 +199,8 @@ pub static PHILOSOPHERS: Example = Example {
     description: "Dining philosophers (2): resource contention",
     source: "{
         fork1!(0) | fork2!(0) |
-        for(fork1->f1){for(fork2->f2){done1!({*(f1) | *(f2)})}} |
-        for(fork2->f2){for(fork1->f1){done2!({*(f2) | *(f1)})}}
+        for(f1 <- fork1){for(f2 <- fork2){done1!({*(f1) | *(f2)})}} |
+        for(f2 <- fork2){for(f1 <- fork1){done2!({*(f2) | *(f1)})}}
     }",
     category: ExampleCategory::Advanced,
     language: LanguageName::RhoCalculus,
@@ -210,9 +210,9 @@ pub static REPLICATED_INPUT: Example = Example {
     name: "replicated_input",
     description: "Replication encoding: persistent input listener",
     source: "{
-        for(dup->y){ {*(y) | dup!(*(y))} },
-        dup!(for(req->x){
-            { resp!(*(x)) | for(dup->y){ {*(y) | dup!(*(y))} } }
+        for(y <- dup){ {*(y) | dup!(*(y))} },
+        dup!(for(x <- req){
+            { resp!(*(x)) | for(y <- dup){ {*(y) | dup!(*(y))} } }
         }),
         req!(0)
     }",
@@ -237,9 +237,9 @@ pub static FANOUT: Example = Example {
     description: "Wide fanout: one-to-many broadcast (performance benchmark)",
     source: "{
         bcast!(0) |
-        for(bcast->x){{a!(*x) | b!(*x) | c!(*x) | d!(*x) | e!(*x) | f!(*x) | g!(*x) | h!(*x)}},
-        for(a->y){*(y)  } | for(b->y){*(y)  } | for(c->y){*(y)  } | for(d->y){*(y)  } |
-        for(e->y){*(y)  } | for(f->y){*(y)  } | for(g->y){*(y)  } | for(h->y){*(y)  }
+        for(x <- bcast){{a!(*x) | b!(*x) | c!(*x) | d!(*x) | e!(*x) | f!(*x) | g!(*x) | h!(*x)}},
+        for(y <- a){*(y)  } | for(y <- b){*(y)  } | for(y <- c){*(y)  } | for(y <- d){*(y)  } |
+        for(y <- e){*(y)  } | for(y <- f){*(y)  } | for(y <- g){*(y)  } | for(y <- h){*(y)  }
     }",
     category: ExampleCategory::Performance,
     language: LanguageName::RhoCalculus,
@@ -250,12 +250,12 @@ pub static PIPELINE: Example = Example {
     description: "Deep pipeline: sequential message passing (depth benchmark)",
     source: "{
         a!(0) |
-        for(a->x){b!(*(x))} |
-        for(b->x){c!(*(x))} |
-        for(c->x){d!(*(x))} |
-        for(d->x){e!(*(x))} |
-        for(e->x){f!(*(x))} |
-        for(f->x){*(x)  }
+        for(x <- a){b!(*(x))} |
+        for(x <- b){c!(*(x))} |
+        for(x <- c){d!(*(x))} |
+        for(x <- d){e!(*(x))} |
+        for(x <- e){f!(*(x))} |
+        for(x <- f){*(x)  }
     }",
     category: ExampleCategory::Performance,
     language: LanguageName::RhoCalculus,
@@ -276,7 +276,7 @@ pub static EMPTY: Example = Example {
 pub static SELF_COMM: Example = Example {
     name: "self_comm",
     description: "Self-communication (infinite loop)",
-    source: "{for(x->y){x!(*(y))} | x!(@(0))}",
+    source: "{for(y <- x){x!(*(y))} | x!(@(0))}",
     category: ExampleCategory::EdgeCase,
     language: LanguageName::RhoCalculus,
 };

--- a/repl/src/examples/rhocalc.txt
+++ b/repl/src/examples/rhocalc.txt
@@ -1,30 +1,30 @@
 // examples
-add = { a!(2) | b!(3) | (a?x,b?y).{ *(x) + *(y) } }
-comm = { a!(0) | (a?x).{*(x)}}
-multi_comm = {a!(p) | b!(q) | c!(r) | (a?x, b?y, c?z).{{*(x) | *(y) | *(z)}}}
+add = { a!(2) | b!(3) | (x<-a,y<-b){ *(x) + *(y) } }
+comm = { a!(0) | (x<-a){*(x)}}
+multi_comm = {a!(p) | b!(q) | c!(r) | (x<-a, y<-b, z<-c){{*(x) | *(y) | *(z)}}}
 
-new_test = {a!(0) | new (x) in { (a?z).{*(z)}} }
+new_test = {a!(0) | new (x) in { (z<-a){*(z)}} }
 
 // duplication and replication
-dup = ^l.{(l?x).{{*(x)|l!(*(x))}}}
-rep = ^n.{^a.{^cont.{{$name(dup,n)|n!((a?y).{{$name(cont,y)|$name(dup,n)}})}}}}
+dup = ^l.{(x <- l){{*(x)|l!(*(x))}}}
+rep = ^n.{^a.{^cont.{{$name(dup,n)|n!((y <- a){{$name(cont,y)|$name(dup,n)}})}}}}
 
 rep_serv = $proc($name($name(rep, loc), serv), id)
 
 // some combinators
 id = ^z.{*(z)}
-fwd = ^src.{^dst.{(src?x).{dst!(*(x))}}}
-const = ^val.{^n.{(n?x).{*(val)}}}
+fwd = ^src.{^dst.{(x <- src){dst!(*(x))}}}
+const = ^val.{^n.{(x <- n){*(val)}}}
 
 // a data structure
 cell = ^loc.{^init.{loc!(init)}}
-read = ^loc.{^ret.{(loc?x).{{loc!(*(x)) | ret!(*(x))}}}}
-write = ^loc.{^val.{(loc?x).{loc!(val)}}}
+read = ^loc.{^ret.{(x <- loc){{loc!(*(x)) | ret!(*(x))}}}}
+write = ^loc.{^val.{(x <- loc){loc!(val)}}}
 
 // List and Bag (communication then operation, like add)
-list_concat_comm = { a!( [ 1, 2 ] ) | b!( [ 3, 4 ] ) | (a?x, b?y).{ concat(*(x), *(y)) } }
-list_len_comm = { a!( [ 1, 2, 3 ] ) | (a?x).{ len(*(x)) } }
-list_at_comm = { a!( [ 1, 2, 3 ] ) | b!( 1 ) | (a?lst, b?i).{ at(*(lst), *(i)) } }
-bag_union_comm = { a!( #{ 1 | 2 }# ) | b!( #{ 2 | 3 }# ) | (a?x, b?y).{ union(*(x), *(y)) } }
-bag_count_comm = { a!( #{ 1 | 2 | 2 }# ) | c!( 2 ) | (a?b, c?e).{ count(*(b), *(e)) } }
-bag_remove_comm = { a!( #{ 1 | 2 | 2 }# ) | c!( 2 ) | (a?b, c?e).{ remove(*(b), *(e)) } }
+list_concat_comm = { a!( [ 1, 2 ] ) | b!( [ 3, 4 ] ) | (x <- a, y <- b){ concat(*(x), *(y)) } }
+list_len_comm = { a!( [ 1, 2, 3 ] ) | (x <- a){ len(*(x)) } }
+list_at_comm = { a!( [ 1, 2, 3 ] ) | b!( 1 ) | (lst <- a, i <- b){ at(*(lst), *(i)) } }
+bag_union_comm = { a!( #{ 1 | 2 }# ) | b!( #{ 2 | 3 }# ) | (x <- a, y <- b){ union(*(x), *(y)) } }
+bag_count_comm = { a!( #{ 1 | 2 | 2 }# ) | c!( 2 ) | (b <- a, e <- c){ count(*(b), *(e)) } }
+bag_remove_comm = { a!( #{ 1 | 2 | 2 }# ) | c!( 2 ) | (b <- a, e <- c){ remove(*(b), *(e)) } }


### PR DESCRIPTION
Implements pattern-based communication guarded by a new unification premise, integrated into the existing premise → condition → Ascent clause pipeline.

It adds a new premise form unifies(pat, val) (parsed as Premise::Unification) with validation that the referenced identifiers are in scope. Codegen now auto-declares unifies_<cat>(Cat, Cat) relations for all language categories and lowers unifies(pat, val) into an Ascent body literal unifies_<cat>(pattern_expr, value_expr), so rules that depend on matching only fire once that relation has been computed to fixpoint. A new macros/src/logic/unification.rs module is wired into Ascent generation to populate these relations.

On the runtime side, the generated term ops gain pattern_matches(value) to decide directional matches and apply_pattern(pattern, value) to deterministically reconstruct variable bindings from a successful match and apply capture-avoiding multi-substitution to the body.

In rhocalc, this introduces PFor(pat, n, body) (a single-channel receive with a Proc pattern) and a new CommPattern rewrite that uses the unifies(pat, q) guard and applies (apply_pattern pat q body) on the RHS.