### PR TITLE
Request response pattern

### DIFF
--- a/languages/src/rhocalc.rs
+++ b/languages/src/rhocalc.rs
@@ -89,7 +89,17 @@ language! {
                 Box::new(n.clone()),
                 Box::new(Proc::CastList(Box::new(List::ListLit(items)))),
             )
-        }] fold;
+        }];
+        POutputParen2Plus . n:Name, a:Proc, bs:Vec(Proc)
+        |- "(" n ")" "!" "(" a "," bs.*sep(",") ")" : Proc ![{
+            let mut items = Vec::with_capacity(1 + bs.len());
+            items.push(a.clone());
+            items.extend(bs.clone());
+            Proc::POutput(
+                Box::new(n.clone()),
+                Box::new(Proc::CastList(Box::new(List::ListLit(items)))),
+            )
+        }];
         POutputQuoted . n:Name, q:Proc
         |- "@" n "!" "(" q ")" : Proc ![{
             Proc::POutput(Box::new(Name::NQuote(Box::new(crate::rhocalc::receive::name_pattern_to_proc(&n)))), Box::new(q.clone()))
@@ -124,18 +134,10 @@ language! {
         }] fold;
         InputBindQuotedQuery . pat:Proc, n:Name, args:Vec(Proc)
         |- "@" pat "<-" n "!" "?" "(" args.*sep(",") ")" : InputBind ![{
-            InputBind::InputBindQuotedQuery(
-                Box::new(pat.clone()),
+            InputBind::InputBindQuery(
+                Box::new(Name::NQuote(Box::new(pat.clone()))),
                 Box::new(n.clone()),
                 args.clone(),
-            )
-        }] fold;
-
-        InputBindQuoted . pat:Proc, n:Name
-        |- "@" pat "<-" n : InputBind ![{
-            InputBind::InputBindQuoted(
-                Box::new(pat.clone()),
-                Box::new(n.clone()),
             )
         }] fold;
         InputBind . lhs:Name, n:Name
@@ -167,7 +169,7 @@ language! {
         PForUser . rows:Vec(ForRow), body:Proc
         |- "for" "(" rows.*sep(";") ")" "{" body "}" : Proc ![{
             crate::rhocalc::receive::desugar_for_rows(rows, body)
-        }] fold;
+        }];
 
 
         NQuote . p:Proc
@@ -1169,4 +1171,55 @@ language! {
         //     proc(p),name(n),
         //     !(proc(k), trans(p,k,q), can_comm(q,n));
     },
+}
+
+fn normalize_query_send_sugar_proc(p: &Proc) -> Proc {
+    match p {
+        Proc::POutput2Plus(n, a, bs) => {
+            let a_norm = normalize_query_send_sugar_proc(a.as_ref());
+            let bs_norm: Vec<Proc> = bs.iter().map(normalize_query_send_sugar_proc).collect();
+            let mut items = Vec::with_capacity(1 + bs_norm.len());
+            items.push(a_norm);
+            items.extend(bs_norm);
+            Proc::POutput(
+                Box::new(n.as_ref().clone()),
+                Box::new(Proc::CastList(Box::new(List::ListLit(items)))),
+            )
+        },
+        Proc::PForUser(rows, body) => {
+            let body_norm = normalize_query_send_sugar_proc(body.as_ref());
+            if crate::rhocalc::receive::pfor_user_still_has_query_rows(rows) {
+                normalize_query_send_sugar_proc(&crate::rhocalc::receive::desugar_for_rows(
+                    rows.clone(),
+                    &body_norm,
+                ))
+            } else {
+                Proc::PForUser(rows.clone(), Box::new(body_norm))
+            }
+        },
+        Proc::PPar(ps) => {
+            let mut out = mettail_runtime::HashBag::new();
+            for (elem, count) in ps.iter() {
+                let norm_elem = normalize_query_send_sugar_proc(elem);
+                for _ in 0..count {
+                    out.insert(norm_elem.clone());
+                }
+            }
+            Proc::PPar(out)
+        },
+        Proc::PNew(scope) => {
+            let (binders, body) = scope.clone().unbind();
+            let norm_body = normalize_query_send_sugar_proc(&body);
+            Proc::PNew(mettail_runtime::Scope::new(binders, Box::new(norm_body)))
+        },
+        _ => p.clone(),
+    }
+}
+
+impl Proc {
+    pub fn term_eq(&self, other: &Self) -> bool {
+        let lhs = normalize_query_send_sugar_proc(self);
+        let rhs = normalize_query_send_sugar_proc(other);
+        mettail_runtime::BoundTerm::term_eq(&lhs, &rhs)
+    }
 }

--- a/languages/src/rhocalc.rs
+++ b/languages/src/rhocalc.rs
@@ -77,6 +77,19 @@ language! {
 
         POutput . n:Name, q:Proc
         |- n "!" "(" q ")" : Proc ;
+        // Sugar for polyadic send: `x!(a, b, c)` is parsed as `x!([a, b, c])`.
+        //
+        // Placing this rule after unary keeps existing unary send parsing stable.
+        POutput2Plus . n:Name, a:Proc, bs:Vec(Proc)
+        |- n "!" "(" a "," bs.*sep(",") ")" : Proc ![{
+            let mut items = Vec::with_capacity(1 + bs.len());
+            items.push(a.clone());
+            items.extend(bs.clone());
+            Proc::POutput(
+                Box::new(n.clone()),
+                Box::new(Proc::CastList(Box::new(List::ListLit(items)))),
+            )
+        }] fold;
         POutputQuoted . n:Name, q:Proc
         |- "@" n "!" "(" q ")" : Proc ![{
             Proc::POutput(Box::new(Name::NQuote(Box::new(crate::rhocalc::receive::name_pattern_to_proc(&n)))), Box::new(q.clone()))
@@ -105,17 +118,30 @@ language! {
         }] fold;
 
         // Single pattern/channel binding.
-        InputBind . lhs:Name, n:Name
-        |- lhs "<-" n : InputBind ![{
-            InputBind::InputBind(
+        //
+        // Query bind sugar: `ptrn <- x!?(a1, ..., ak)` means "send a request to `x` and
+        // bind `ptrn` from a private return channel". This is desugared by `for (...) { ... }`
+        // folding in `receive::desugar_for_rows`.
+        InputBindQuery . lhs:Name, n:Name, args:Vec(Proc)
+        |- lhs "<-" n "!?" "(" args.*sep(",") ")" : InputBind ![{
+            InputBind::InputBindQuery(
                 Box::new(lhs.clone()),
                 Box::new(n.clone()),
+                args.clone(),
             )
         }] fold;
+
         InputBindQuoted . pat:Proc, n:Name
         |- "@" pat "<-" n : InputBind ![{
             InputBind::InputBindQuoted(
                 Box::new(pat.clone()),
+                Box::new(n.clone()),
+            )
+        }] fold;
+        InputBind . lhs:Name, n:Name
+        |- lhs "<-" n : InputBind ![{
+            InputBind::InputBind(
+                Box::new(lhs.clone()),
                 Box::new(n.clone()),
             )
         }] fold;

--- a/languages/src/rhocalc.rs
+++ b/languages/src/rhocalc.rs
@@ -95,14 +95,6 @@ language! {
             Proc::POutput(Box::new(Name::NQuote(Box::new(crate::rhocalc::receive::name_pattern_to_proc(&n)))), Box::new(q.clone()))
         }] fold;
 
-        // Internal constructor for single-input receive with optional where-guard.
-        PForWhere . pat:Proc, n:Name, cond:Proc, body:Proc
-        |- "__for_where" "(" pat "<-" n "where" cond ")" "{" body "}" : Proc;
-
-        // Internal constructor for single-input receive used by guarded COMM.
-        PFor . pat:Proc, n:Name, body:Proc
-        |- "__for" "(" pat "<-" n ")" "{" body "}" : Proc;
-
         // Internal guard gate used by where-clause gating.
         GuardThen . cond:Proc, body:Proc
         |- "__guard_then" "(" cond "," body ")" : Proc ![{
@@ -123,9 +115,17 @@ language! {
         // bind `ptrn` from a private return channel". This is desugared by `for (...) { ... }`
         // folding in `receive::desugar_for_rows`.
         InputBindQuery . lhs:Name, n:Name, args:Vec(Proc)
-        |- lhs "<-" n "!?" "(" args.*sep(",") ")" : InputBind ![{
+        |- lhs "<-" n "!" "?" "(" args.*sep(",") ")" : InputBind ![{
             InputBind::InputBindQuery(
                 Box::new(lhs.clone()),
+                Box::new(n.clone()),
+                args.clone(),
+            )
+        }] fold;
+        InputBindQuotedQuery . pat:Proc, n:Name, args:Vec(Proc)
+        |- "@" pat "<-" n "!" "?" "(" args.*sep(",") ")" : InputBind ![{
+            InputBind::InputBindQuotedQuery(
+                Box::new(pat.clone()),
                 Box::new(n.clone()),
                 args.clone(),
             )
@@ -160,13 +160,10 @@ language! {
         ForRowSingleNoWhere . b:InputBind
         |- b : ForRow;
 
-        // Internal multi-channel receive created by PForRows desugaring.
-        // Not user-facing; uses __ prefix to avoid collision with user syntax.
-        PForJoin . b:InputBind, bs:Vec(InputBind), cond:Proc, body:Proc
-        |- "__for_join" "(" b "&" bs.*sep("&") "where" cond ")" "{" body "}" : Proc;
-
-        // User-facing `for` syntax: rows joined by `;` are nested (right fold), and each row
-        // can contain `&`-joined binds with optional `where`.
+        // `for` syntax: semicolon rows nest conceptually (outer = first row); `&` with optional
+        // `where` in one row is one receive surface. All parse to a single `PForUser` term; query
+        // `!?(...)` and COMM semantics are handled in `receive` + rewrites, not desugared
+        // into extra Proc constructors.
         PForUser . rows:Vec(ForRow), body:Proc
         |- "for" "(" rows.*sep(";") ")" "{" body "}" : Proc ![{
             crate::rhocalc::receive::desugar_for_rows(rows, body)
@@ -943,20 +940,8 @@ language! {
 
     rewrites {
 
-        // Pattern-based communication (single channel): if payload matches pattern, apply substitution into body.
-        CommPattern . | unifies(pat, q) |- (PPar {(PFor pat n body), (POutput n q), ...rest})
-            ~> (PPar {(apply_pattern pat q body), ...rest});
-
-        // Pattern communication with optional where-guard:
-        // reduce only when pattern unifies and substituted guard is true;
-        // otherwise keep the receive/send pair unchanged (blocked communication).
-        CommPatternWhere . | unifies(pat, q)
-            |- (PPar {(PForWhere pat n cond body), (POutput n q), ...rest})
-            ~> (PPar {(CommWhere pat n q cond body), ...rest});
-
-        // Zip+Map codegen derives `ns` from `b`/`bs` (see `pattern.rs` + `receive::channel_names_from_row`).
-        Comm . |- (PPar {(PForJoin b bs cond body), *zip(ns,qs).*map(|n,q| (POutput n q)), ...rest})
-            ~> (PPar {(comm_join b bs ns qs cond body), ...rest});
+        // Communication for `PForUser` (single- and multi-`&` receive rows) lives in
+        // `receive::try_comm_rw_proc` plus a custom `rw_proc` rule in the logic block below.
 
         Exec . |- (PDrop (NQuote P)) ~> P;
         ExecParenQuote . |- (PDrop (NParen (NQuote P))) ~> P;
@@ -1072,6 +1057,20 @@ language! {
     },
 
     logic {
+        // Normalize polyadic send sugar `x!(a, b, ...)` to unary send with list payload.
+        fold_proc(s.clone(), res) <--
+            proc(s),
+            if let Proc::POutput2Plus(ref n, ref a, ref bs) = s,
+            let res = {
+                let mut items = Vec::with_capacity(1 + bs.len());
+                items.push(a.as_ref().clone());
+                items.extend(bs.iter().cloned());
+                Proc::POutput(
+                    Box::new(n.as_ref().clone()),
+                    Box::new(Proc::CastList(Box::new(List::ListLit(items)))),
+                )
+            };
+
         // fold *(@(P)) to P so that remove(*(@(bag)), *(@(elem))) can reduce (Exec semantics in fold)
         fold_proc(s.clone(), res) <--
             proc(s),
@@ -1094,15 +1093,23 @@ language! {
                 body.as_ref(),
             );
 
-        // Desugar user-facing `for (...) { ... }` into internal receive forms so
-        // COMM/Extrusion rewrites (which match `PFor` / `PForJoin`) can fire.
+        // Desugar `!?` query binds inside `PForUser` (parse may leave `InputBindQuery` in rows; idempotent).
         fold_proc(s.clone(), res) <--
             proc(s),
             if let Proc::PForUser(ref rows, ref body) = s,
+            if crate::rhocalc::receive::pfor_user_still_has_query_rows(rows),
             let res = crate::rhocalc::receive::desugar_for_rows(rows.clone(), body.as_ref());
+
+        // `PForUser` communication (replaces declarative Comm* rewrites on `PFor` / `PForWhere` / `PForJoin`).
+        rw_proc(s0.clone(), res) <--
+            eq_proc(s0, s),
+            if let Some(rewritten) = crate::rhocalc::receive::try_comm_rw_proc(&s),
+            if rewritten != *s,
+            let res = rewritten;
 
         // many-step to a result
         relation path(Proc, Proc);
+        path(p0, p1) <-- fold_proc(p0, p1);
         path(p0, p1) <-- rw_proc(p0, p1);
         path(p0, p2) <-- path(p0, p1), path(p1, p2);
 

--- a/languages/src/rhocalc.rs
+++ b/languages/src/rhocalc.rs
@@ -89,17 +89,7 @@ language! {
                 Box::new(n.clone()),
                 Box::new(Proc::CastList(Box::new(List::ListLit(items)))),
             )
-        }];
-        POutputParen2Plus . n:Name, a:Proc, bs:Vec(Proc)
-        |- "(" n ")" "!" "(" a "," bs.*sep(",") ")" : Proc ![{
-            let mut items = Vec::with_capacity(1 + bs.len());
-            items.push(a.clone());
-            items.extend(bs.clone());
-            Proc::POutput(
-                Box::new(n.clone()),
-                Box::new(Proc::CastList(Box::new(List::ListLit(items)))),
-            )
-        }];
+        }] fold;
         POutputQuoted . n:Name, q:Proc
         |- "@" n "!" "(" q ")" : Proc ![{
             Proc::POutput(Box::new(Name::NQuote(Box::new(crate::rhocalc::receive::name_pattern_to_proc(&n)))), Box::new(q.clone()))
@@ -134,10 +124,18 @@ language! {
         }] fold;
         InputBindQuotedQuery . pat:Proc, n:Name, args:Vec(Proc)
         |- "@" pat "<-" n "!" "?" "(" args.*sep(",") ")" : InputBind ![{
-            InputBind::InputBindQuery(
-                Box::new(Name::NQuote(Box::new(pat.clone()))),
+            InputBind::InputBindQuotedQuery(
+                Box::new(pat.clone()),
                 Box::new(n.clone()),
                 args.clone(),
+            )
+        }] fold;
+
+        InputBindQuoted . pat:Proc, n:Name
+        |- "@" pat "<-" n : InputBind ![{
+            InputBind::InputBindQuoted(
+                Box::new(pat.clone()),
+                Box::new(n.clone()),
             )
         }] fold;
         InputBind . lhs:Name, n:Name
@@ -169,7 +167,7 @@ language! {
         PForUser . rows:Vec(ForRow), body:Proc
         |- "for" "(" rows.*sep(";") ")" "{" body "}" : Proc ![{
             crate::rhocalc::receive::desugar_for_rows(rows, body)
-        }];
+        }] fold;
 
 
         NQuote . p:Proc

--- a/languages/src/rhocalc/receive.rs
+++ b/languages/src/rhocalc/receive.rs
@@ -2,7 +2,7 @@ use super::{
     Bag, BigInt, BigRat, Bool, Fixed, Float, ForRow, InputBind, Int, List, Map, Name, Proc, Str,
     UInt32,
 };
-use mettail_runtime::{FreeVar, HashBag, OrdVar, Var};
+use mettail_runtime::{Binder, FreeVar, HashBag, OrdVar, Scope, Var};
 use std::cmp::Ordering;
 use std::collections::HashMap;
 
@@ -18,6 +18,7 @@ fn bind_pattern_proc(bind: &InputBind) -> Option<Proc> {
     match bind {
         InputBind::InputBind(lhs, _) => Some(name_pattern_to_proc(lhs.as_ref())),
         InputBind::InputBindQuoted(pat, _) => Some(pat.as_ref().clone()),
+        InputBind::InputBindQuery(lhs, _, _) => Some(name_pattern_to_proc(lhs.as_ref())),
         _ => None,
     }
 }
@@ -26,6 +27,7 @@ fn bind_channel_name(bind: &InputBind) -> Option<&Name> {
     match bind {
         InputBind::InputBind(_, n) => Some(n.as_ref()),
         InputBind::InputBindQuoted(_, n) => Some(n.as_ref()),
+        InputBind::InputBindQuery(_, n, _) => Some(n.as_ref()),
         _ => None,
     }
 }
@@ -236,32 +238,113 @@ pub fn comm_pforwhere_subst(pat: &Proc, n: &Name, q: &Proc, cond: &Proc, body: &
     }
 }
 
-fn apply_row(row: ForRow, inner: Proc) -> Proc {
-    match row {
-        ForRow::ForRowSingleNoWhere(b) => match *b {
-            InputBind::InputBind(lhs, n) => {
-                Proc::PFor(Box::new(name_pattern_to_proc(lhs.as_ref())), n, Box::new(inner))
-            },
-            InputBind::InputBindQuoted(pat, n) => Proc::PFor(pat, n, Box::new(inner)),
-            _ => Proc::Err,
+fn fresh_query_return(counter: &mut usize) -> (Binder<String>, Name) {
+    let idx = *counter;
+    *counter += 1;
+    let fv: FreeVar<String> = FreeVar::fresh_named(format!("__r{}", idx));
+    let binder = Binder(fv.clone());
+    let name = Name::NVar(OrdVar(Var::Free(fv)));
+    (binder, name)
+}
+
+fn mk_query_send(channel: &Name, ret: &Name, args: &[Proc]) -> Proc {
+    let mut items = Vec::with_capacity(1 + args.len());
+    items.push(Proc::PDrop(Box::new(ret.clone())));
+    items.extend(args.iter().cloned());
+    Proc::POutput(
+        Box::new(channel.clone()),
+        Box::new(Proc::CastList(Box::new(List::ListLit(items)))),
+    )
+}
+
+fn desugar_query_bind(
+    bind: InputBind,
+    counter: &mut usize,
+) -> (InputBind, Vec<(Binder<String>, Proc)>) {
+    match bind {
+        InputBind::InputBindQuery(lhs, channel, args) => {
+            let (binder, ret_name) = fresh_query_return(counter);
+            let recv_bind = InputBind::InputBind(lhs, Box::new(ret_name.clone()));
+            let send = mk_query_send(channel.as_ref(), &ret_name, &args);
+            (recv_bind, vec![(binder, send)])
         },
-        ForRow::ForRowSingleWhere(b, cond) => match *b {
-            InputBind::InputBind(lhs, n) => Proc::PForWhere(
-                Box::new(name_pattern_to_proc(lhs.as_ref())),
-                n,
-                cond,
-                Box::new(inner),
-            ),
-            InputBind::InputBindQuoted(pat, n) => Proc::PForWhere(pat, n, cond, Box::new(inner)),
-            _ => Proc::Err,
+        other => (other, vec![]),
+    }
+}
+
+fn apply_row_with_query_sugar(row: ForRow, inner: Proc, counter: &mut usize) -> Proc {
+    let (receive_proc, query_binders_and_sends): (Proc, Vec<(Binder<String>, Proc)>) = match row {
+        ForRow::ForRowSingleNoWhere(b) => {
+            let (b2, sends) = desugar_query_bind(*b, counter);
+            let recv = match b2 {
+                InputBind::InputBind(lhs, n) => {
+                    Proc::PFor(Box::new(name_pattern_to_proc(lhs.as_ref())), n, Box::new(inner))
+                },
+                InputBind::InputBindQuoted(pat, n) => Proc::PFor(pat, n, Box::new(inner)),
+                _ => Proc::Err,
+            };
+            (recv, sends)
+        },
+        ForRow::ForRowSingleWhere(b, cond) => {
+            let (b2, sends) = desugar_query_bind(*b, counter);
+            let recv = match b2 {
+                InputBind::InputBind(lhs, n) => Proc::PForWhere(
+                    Box::new(name_pattern_to_proc(lhs.as_ref())),
+                    n,
+                    cond,
+                    Box::new(inner),
+                ),
+                InputBind::InputBindQuoted(pat, n) => {
+                    Proc::PForWhere(pat, n, cond, Box::new(inner))
+                },
+                _ => Proc::Err,
+            };
+            (recv, sends)
         },
         ForRow::ForRowNoWhere(b, bs) => {
+            let mut acc_sends = Vec::new();
+            let (b2, mut sends0) = desugar_query_bind(*b, counter);
+            acc_sends.append(&mut sends0);
+            let mut bs2 = Vec::with_capacity(bs.len());
+            for ib in bs {
+                let (ib2, mut sends_i) = desugar_query_bind(ib, counter);
+                acc_sends.append(&mut sends_i);
+                bs2.push(ib2);
+            }
             let true_cond = Box::new(Proc::CastBool(Box::new(Bool::BoolLit(true))));
-            Proc::PForJoin(b, bs, true_cond, Box::new(inner))
+            (Proc::PForJoin(Box::new(b2), bs2, true_cond, Box::new(inner)), acc_sends)
         },
-        ForRow::ForRowWhere(b, bs, cond) => Proc::PForJoin(b, bs, cond, Box::new(inner)),
-        _ => Proc::Err,
+        ForRow::ForRowWhere(b, bs, cond) => {
+            let mut acc_sends = Vec::new();
+            let (b2, mut sends0) = desugar_query_bind(*b, counter);
+            acc_sends.append(&mut sends0);
+            let mut bs2 = Vec::with_capacity(bs.len());
+            for ib in bs {
+                let (ib2, mut sends_i) = desugar_query_bind(ib, counter);
+                acc_sends.append(&mut sends_i);
+                bs2.push(ib2);
+            }
+            (Proc::PForJoin(Box::new(b2), bs2, cond, Box::new(inner)), acc_sends)
+        },
+        _ => (Proc::Err, vec![]),
+    };
+
+    if query_binders_and_sends.is_empty() {
+        return receive_proc;
     }
+
+    let mut bag = HashBag::new();
+    for (_, send) in &query_binders_and_sends {
+        Proc::insert_into_ppar(&mut bag, send.clone());
+    }
+    Proc::insert_into_ppar(&mut bag, receive_proc);
+    let ppar = Proc::PPar(bag);
+
+    let binders: Vec<Binder<String>> = query_binders_and_sends
+        .into_iter()
+        .map(|(b, _)| b)
+        .collect();
+    Proc::PNew(Scope::new(binders, Box::new(ppar)))
 }
 
 /// Desugar a list of ForRows into nested `for` calls (right-to-left folding so
@@ -270,9 +353,10 @@ fn apply_row(row: ForRow, inner: Proc) -> Proc {
 /// The `body` parameter is taken by reference because Ascent binds fold-relation
 /// results as references in its generated rule code.
 pub fn desugar_for_rows(rows: Vec<ForRow>, body: &Proc) -> Proc {
-    rows.into_iter()
-        .rev()
-        .fold((*body).clone(), |inner, row| apply_row(row, inner))
+    let mut counter = 0usize;
+    rows.into_iter().rev().fold((*body).clone(), |inner, row| {
+        apply_row_with_query_sugar(row, inner, &mut counter)
+    })
 }
 
 pub(crate) fn channel_names_from_row(b: &InputBind, bs: &[InputBind]) -> Option<Vec<Name>> {

--- a/languages/src/rhocalc/receive.rs
+++ b/languages/src/rhocalc/receive.rs
@@ -17,9 +17,7 @@ pub(crate) fn name_pattern_to_proc(name_pat: &Name) -> Proc {
 pub(crate) fn bind_pattern_proc(bind: &InputBind) -> Option<Proc> {
     match bind {
         InputBind::InputBind(lhs, _) => Some(name_pattern_to_proc(lhs.as_ref())),
-        InputBind::InputBindQuoted(pat, _) => Some(pat.as_ref().clone()),
         InputBind::InputBindQuery(lhs, _, _) => Some(name_pattern_to_proc(lhs.as_ref())),
-        InputBind::InputBindQuotedQuery(pat, _, _) => Some(pat.as_ref().clone()),
         _ => None,
     }
 }
@@ -27,9 +25,7 @@ pub(crate) fn bind_pattern_proc(bind: &InputBind) -> Option<Proc> {
 fn bind_channel_name(bind: &InputBind) -> Option<&Name> {
     match bind {
         InputBind::InputBind(_, n) => Some(n.as_ref()),
-        InputBind::InputBindQuoted(_, n) => Some(n.as_ref()),
         InputBind::InputBindQuery(_, n, _) => Some(n.as_ref()),
-        InputBind::InputBindQuotedQuery(_, n, _) => Some(n.as_ref()),
         _ => None,
     }
 }
@@ -250,12 +246,16 @@ fn fresh_query_return(counter: &mut usize) -> (Binder<String>, Name) {
 }
 
 fn mk_query_send(channel: &Name, ret: &Name, args: &[Proc]) -> Proc {
-    let mut items = Vec::with_capacity(1 + args.len());
-    items.push(Proc::PDrop(Box::new(ret.clone())));
-    items.extend(args.iter().cloned());
-    Proc::POutput(
+    if args.is_empty() {
+        return Proc::POutput(
+            Box::new(channel.clone()),
+            Box::new(Proc::PDrop(Box::new(ret.clone()))),
+        );
+    }
+    Proc::POutput2Plus(
         Box::new(channel.clone()),
-        Box::new(Proc::CastList(Box::new(List::ListLit(items)))),
+        Box::new(Proc::PDrop(Box::new(ret.clone()))),
+        args.to_vec(),
     )
 }
 
@@ -270,34 +270,22 @@ fn desugar_query_bind(
             let send = mk_query_send(channel.as_ref(), &ret_name, &args);
             (recv_bind, vec![(binder, send)])
         },
-        InputBind::InputBindQuotedQuery(pat, channel, args) => {
-            let (binder, ret_name) = fresh_query_return(counter);
-            let recv_bind = InputBind::InputBindQuoted(pat, Box::new(ret_name.clone()));
-            let send = mk_query_send(channel.as_ref(), &ret_name, &args);
-            (recv_bind, vec![(binder, send)])
-        },
         other => (other, vec![]),
     }
 }
 
-fn pfor_user_one_row(row: ForRow, body: Proc) -> Proc {
-    Proc::PForUser(vec![row], Box::new(body))
-}
-
-fn apply_row_with_query_sugar(row: ForRow, inner: Proc, counter: &mut usize) -> Proc {
-    let (receive_proc, query_binders_and_sends): (Proc, Vec<(Binder<String>, Proc)>) = match row {
+fn desugar_row_query_binds(
+    row: ForRow,
+    counter: &mut usize,
+) -> (ForRow, Vec<(Binder<String>, Proc)>) {
+    match row {
         ForRow::ForRowSingleNoWhere(b) => {
             let (b2, sends) = desugar_query_bind(*b, counter);
-            let recv = pfor_user_one_row(ForRow::ForRowSingleNoWhere(Box::new(b2)), inner);
-            (recv, sends)
+            (ForRow::ForRowSingleNoWhere(Box::new(b2)), sends)
         },
         ForRow::ForRowSingleWhere(b, cond) => {
             let (b2, sends) = desugar_query_bind(*b, counter);
-            let recv = pfor_user_one_row(
-                ForRow::ForRowSingleWhere(Box::new(b2), cond),
-                inner,
-            );
-            (recv, sends)
+            (ForRow::ForRowSingleWhere(Box::new(b2), cond), sends)
         },
         ForRow::ForRowNoWhere(b, bs) => {
             let mut acc_sends = Vec::new();
@@ -309,10 +297,7 @@ fn apply_row_with_query_sugar(row: ForRow, inner: Proc, counter: &mut usize) -> 
                 acc_sends.append(&mut sends_i);
                 bs2.push(ib2);
             }
-            (
-                pfor_user_one_row(ForRow::ForRowNoWhere(Box::new(b2), bs2), inner),
-                acc_sends,
-            )
+            (ForRow::ForRowNoWhere(Box::new(b2), bs2), acc_sends)
         },
         ForRow::ForRowWhere(b, bs, cond) => {
             let mut acc_sends = Vec::new();
@@ -324,64 +309,29 @@ fn apply_row_with_query_sugar(row: ForRow, inner: Proc, counter: &mut usize) -> 
                 acc_sends.append(&mut sends_i);
                 bs2.push(ib2);
             }
-            (pfor_user_one_row(ForRow::ForRowWhere(Box::new(b2), bs2, cond), inner), acc_sends)
+            (ForRow::ForRowWhere(Box::new(b2), bs2, cond), acc_sends)
         },
-        _ => (Proc::Err, vec![]),
-    };
-
-    if query_binders_and_sends.is_empty() {
-        return receive_proc;
+        _ => (row, vec![]),
     }
-
-    let mut bag = HashBag::new();
-    for (_, send) in &query_binders_and_sends {
-        Proc::insert_into_ppar(&mut bag, send.clone());
-    }
-    Proc::insert_into_ppar(&mut bag, receive_proc);
-    let ppar = Proc::PPar(bag);
-
-    let binders: Vec<Binder<String>> = query_binders_and_sends
-        .into_iter()
-        .map(|(b, _)| b)
-        .collect();
-    Proc::PNew(Scope::new(binders, Box::new(ppar)))
 }
 
 /// True if any `ForRow` still uses `InputBindQuery` / `InputBindQuotedQuery` (parse-time
 /// fold should have removed these; this supports a `fold_proc` idempotent pass).
 pub fn pfor_user_still_has_query_rows(rows: &[ForRow]) -> bool {
     rows.iter().any(|row| match row {
-        ForRow::ForRowSingleNoWhere(b) => matches!(
-            b.as_ref(),
-            InputBind::InputBindQuery(_, _, _) | InputBind::InputBindQuotedQuery(_, _, _)
-        ),
-        ForRow::ForRowSingleWhere(b, _) => matches!(
-            b.as_ref(),
-            InputBind::InputBindQuery(_, _, _) | InputBind::InputBindQuotedQuery(_, _, _)
-        ),
+        ForRow::ForRowSingleNoWhere(b) => matches!(b.as_ref(), InputBind::InputBindQuery(_, _, _)),
+        ForRow::ForRowSingleWhere(b, _) => matches!(b.as_ref(), InputBind::InputBindQuery(_, _, _)),
         ForRow::ForRowNoWhere(b, bs) => {
-            matches!(
-                b.as_ref(),
-                InputBind::InputBindQuery(_, _, _) | InputBind::InputBindQuotedQuery(_, _, _)
-            ) || bs.iter().any(|ib| {
-                matches!(
-                    ib,
-                    InputBind::InputBindQuery(_, _, _)
-                        | InputBind::InputBindQuotedQuery(_, _, _)
-                )
-            })
+            matches!(b.as_ref(), InputBind::InputBindQuery(_, _, _))
+                || bs
+                    .iter()
+                    .any(|ib| matches!(ib, InputBind::InputBindQuery(_, _, _)))
         },
         ForRow::ForRowWhere(b, bs, _) => {
-            matches!(
-                b.as_ref(),
-                InputBind::InputBindQuery(_, _, _) | InputBind::InputBindQuotedQuery(_, _, _)
-            ) || bs.iter().any(|ib| {
-                matches!(
-                    ib,
-                    InputBind::InputBindQuery(_, _, _)
-                        | InputBind::InputBindQuotedQuery(_, _, _)
-                )
-            })
+            matches!(b.as_ref(), InputBind::InputBindQuery(_, _, _))
+                || bs
+                    .iter()
+                    .any(|ib| matches!(ib, InputBind::InputBindQuery(_, _, _)))
         },
         _ => false,
     })
@@ -394,9 +344,30 @@ pub fn pfor_user_still_has_query_rows(rows: &[ForRow]) -> bool {
 /// results as references in its generated rule code.
 pub fn desugar_for_rows(rows: Vec<ForRow>, body: &Proc) -> Proc {
     let mut counter = 0usize;
-    rows.into_iter().rev().fold((*body).clone(), |inner, row| {
-        apply_row_with_query_sugar(row, inner, &mut counter)
-    })
+    let mut rewritten_rows = Vec::with_capacity(rows.len());
+    let mut query_binders_and_sends: Vec<(Binder<String>, Proc)> = Vec::new();
+    for row in rows {
+        let (rewritten_row, mut sends) = desugar_row_query_binds(row, &mut counter);
+        rewritten_rows.push(rewritten_row);
+        query_binders_and_sends.append(&mut sends);
+    }
+
+    let receive_proc = Proc::PForUser(rewritten_rows, Box::new((*body).clone()));
+    if query_binders_and_sends.is_empty() {
+        return receive_proc;
+    }
+
+    let mut bag = HashBag::new();
+    for (_, send) in &query_binders_and_sends {
+        Proc::insert_into_ppar(&mut bag, send.clone());
+    }
+    Proc::insert_into_ppar(&mut bag, receive_proc);
+
+    let binders: Vec<Binder<String>> = query_binders_and_sends
+        .into_iter()
+        .map(|(b, _)| b)
+        .collect();
+    Proc::PNew(Scope::new(binders, Box::new(Proc::PPar(bag))))
 }
 
 #[allow(dead_code)]
@@ -409,10 +380,7 @@ pub fn desugar_polyadic_output(n: &Name, a: &Proc, bs: &[Proc]) -> Proc {
     let mut items = Vec::with_capacity(1 + bs.len());
     items.push(a.clone());
     items.extend(bs.iter().cloned());
-    Proc::POutput(
-        Box::new(n.clone()),
-        Box::new(Proc::CastList(Box::new(List::ListLit(items)))),
-    )
+    Proc::POutput(Box::new(n.clone()), Box::new(Proc::CastList(Box::new(List::ListLit(items)))))
 }
 
 fn is_trivially_true_const(p: &Proc) -> bool {
@@ -449,16 +417,9 @@ pub fn comm_pforjoin_subst(
         let row = if is_trivially_true_const(cond) {
             ForRow::ForRowNoWhere(Box::new(b.clone()), bs.to_vec())
         } else {
-            ForRow::ForRowWhere(
-                Box::new(b.clone()),
-                bs.to_vec(),
-                Box::new(cond.clone()),
-            )
+            ForRow::ForRowWhere(Box::new(b.clone()), bs.to_vec(), Box::new(cond.clone()))
         };
-        Proc::insert_into_ppar(
-            &mut bag,
-            Proc::PForUser(vec![row], Box::new(body.clone())),
-        );
+        Proc::insert_into_ppar(&mut bag, Proc::PForUser(vec![row], Box::new(body.clone())));
         for (n, q) in ns.iter().zip(qs.iter()) {
             Proc::insert_into_ppar(
                 &mut bag,
@@ -554,45 +515,17 @@ fn try_comm_on_pfor_user(
     let cont = pfor_continuation_after_first_row(rows, body);
     match &rows[0] {
         ForRow::ForRowSingleNoWhere(b) => {
-            try_comm_single(
-                b.as_ref(),
-                whole_bag,
-                for_key,
-                &cont,
-                false,
-                None,
-            )
+            try_comm_single(b.as_ref(), whole_bag, for_key, &cont, None)
         },
         ForRow::ForRowSingleWhere(b, cond) => {
-            try_comm_single(
-                b.as_ref(),
-                whole_bag,
-                for_key,
-                &cont,
-                true,
-                Some(cond.as_ref()),
-            )
+            try_comm_single(b.as_ref(), whole_bag, for_key, &cont, Some(cond.as_ref()))
         },
         ForRow::ForRowNoWhere(b, bs) => {
             let true_c = Proc::CastBool(Box::new(Bool::BoolLit(true)));
-            try_comm_join(
-                b.as_ref(),
-                bs,
-                &true_c,
-                whole_bag,
-                for_key,
-                &cont,
-            )
+            try_comm_join(b.as_ref(), bs, &true_c, whole_bag, for_key, &cont)
         },
         ForRow::ForRowWhere(b, bs, cond) => {
-            try_comm_join(
-                b.as_ref(),
-                bs,
-                cond.as_ref(),
-                whole_bag,
-                for_key,
-                &cont,
-            )
+            try_comm_join(b.as_ref(), bs, cond.as_ref(), whole_bag, for_key, &cont)
         },
         _ => None,
     }
@@ -603,25 +536,14 @@ fn try_comm_single(
     whole_bag: &HashBag<Proc>,
     for_key: &Proc,
     cont: &Proc,
-    is_where: bool,
     where_cond: Option<&Proc>,
 ) -> Option<Proc> {
     let n_for_output = bind_channel_name(b)?;
     let pat = bind_pattern_proc(b)?;
     for (cand, _) in whole_bag.iter() {
-        if let Proc::POutput(n_out, q) = cand {
+        if let Proc::POutput(n_out, _) = cand {
             if n_out.as_ref() == n_for_output {
-                return finish_single_comm(
-                    whole_bag,
-                    for_key,
-                    cand,
-                    &pat,
-                    n_out,
-                    q.as_ref(),
-                    cont,
-                    is_where,
-                    where_cond,
-                );
+                return finish_single_comm(whole_bag, for_key, cand, &pat, cont, where_cond);
             }
         }
     }
@@ -633,26 +555,25 @@ fn finish_single_comm(
     for_key: &Proc,
     output_key: &Proc,
     pat: &Proc,
-    n_out: &Name,
-    q: &Proc,
     cont: &Proc,
-    is_where: bool,
     where_cond: Option<&Proc>,
 ) -> Option<Proc> {
+    let Proc::POutput(n_out, q) = output_key else {
+        return None;
+    };
     if !pat.pattern_matches(q) {
         return None;
     }
-    let new_center = if is_where {
-        let c = where_cond?;
+    let new_center = if let Some(c) = where_cond {
         Proc::CommWhere(
             Box::new(pat.clone()),
-            Box::new(n_out.clone()),
-            Box::new(q.clone()),
+            Box::new(n_out.as_ref().clone()),
+            Box::new(q.as_ref().clone()),
             Box::new(c.clone()),
             Box::new(cont.clone()),
         )
     } else {
-        cont.apply_pattern(pat, q)?
+        cont.apply_pattern(pat, q.as_ref())?
     };
     ppar_remove_two_insert(whole_bag, for_key, output_key, new_center)
 }

--- a/languages/src/rhocalc/receive.rs
+++ b/languages/src/rhocalc/receive.rs
@@ -383,13 +383,6 @@ pub fn desugar_polyadic_output(n: &Name, a: &Proc, bs: &[Proc]) -> Proc {
     Proc::POutput(Box::new(n.clone()), Box::new(Proc::CastList(Box::new(List::ListLit(items)))))
 }
 
-fn is_trivially_true_const(p: &Proc) -> bool {
-    if let Proc::CastBool(b) = p {
-        return matches!(b.as_ref(), Bool::BoolLit(true));
-    }
-    false
-}
-
 pub(crate) fn channel_names_from_row(b: &InputBind, bs: &[InputBind]) -> Option<Vec<Name>> {
     let mut out = Vec::with_capacity(1 + bs.len());
     out.push(bind_channel_name(b)?.clone());
@@ -411,29 +404,10 @@ pub fn comm_pforjoin_subst(
     qs: &[Proc],
     cond: &Proc,
     body: &Proc,
-) -> Proc {
-    let blocked = || {
-        let mut bag = HashBag::new();
-        let row = if is_trivially_true_const(cond) {
-            ForRow::ForRowNoWhere(Box::new(b.clone()), bs.to_vec())
-        } else {
-            ForRow::ForRowWhere(Box::new(b.clone()), bs.to_vec(), Box::new(cond.clone()))
-        };
-        Proc::insert_into_ppar(&mut bag, Proc::PForUser(vec![row], Box::new(body.clone())));
-        for (n, q) in ns.iter().zip(qs.iter()) {
-            Proc::insert_into_ppar(
-                &mut bag,
-                Proc::POutput(Box::new(n.clone()), Box::new(q.clone())),
-            );
-        }
-        Proc::PPar(bag)
-    };
-
-    let Some(expected_ns) = channel_names_from_row(b, bs) else {
-        return blocked();
-    };
+) -> Option<Proc> {
+    let expected_ns = channel_names_from_row(b, bs)?;
     if expected_ns.len() != ns.len() || expected_ns.len() != qs.len() {
-        return blocked();
+        return None;
     }
     // PPar is a bag; output order in `ns/qs` is not stable. Align payloads to expected channels.
     let mut used = vec![false; ns.len()];
@@ -446,9 +420,7 @@ pub fn comm_pforjoin_subst(
                 break;
             }
         }
-        let Some(idx) = found else {
-            return blocked();
-        };
+        let idx = found?;
         used[idx] = true;
         aligned_qs.push(&qs[idx]);
     }
@@ -456,22 +428,16 @@ pub fn comm_pforjoin_subst(
     let mut acc_body = body.clone();
     let mut acc_cond = cond.clone();
     for (ib, q) in binds.iter().zip(aligned_qs.iter()) {
-        let Some(pat) = bind_pattern_proc(ib) else {
-            return blocked();
-        };
-        let Some(nb) = receive_apply(&pat, q, &acc_body) else {
-            return blocked();
-        };
+        let pat = bind_pattern_proc(ib)?;
+        let nb = receive_apply(&pat, q, &acc_body)?;
         acc_body = nb;
-        let Some(nc) = receive_apply(&pat, q, &acc_cond) else {
-            return blocked();
-        };
+        let nc = receive_apply(&pat, q, &acc_cond)?;
         acc_cond = nc;
     }
 
     match eval_guard_bool(&acc_cond) {
-        Some(true) => acc_body,
-        _ => blocked(),
+        Some(true) => Some(acc_body),
+        _ => None,
     }
 }
 
@@ -627,7 +593,7 @@ fn try_comm_join(
             return None;
         }
     }
-    let res = comm_pforjoin_subst(b, bs, &ns_collected, &qs, cond, cont);
+    let res = comm_pforjoin_subst(b, bs, &ns_collected, &qs, cond, cont)?;
     work.insert(res);
     Some(Proc::PPar(work))
 }

--- a/languages/src/rhocalc/receive.rs
+++ b/languages/src/rhocalc/receive.rs
@@ -14,11 +14,12 @@ pub(crate) fn name_pattern_to_proc(name_pat: &Name) -> Proc {
     }
 }
 
-fn bind_pattern_proc(bind: &InputBind) -> Option<Proc> {
+pub(crate) fn bind_pattern_proc(bind: &InputBind) -> Option<Proc> {
     match bind {
         InputBind::InputBind(lhs, _) => Some(name_pattern_to_proc(lhs.as_ref())),
         InputBind::InputBindQuoted(pat, _) => Some(pat.as_ref().clone()),
         InputBind::InputBindQuery(lhs, _, _) => Some(name_pattern_to_proc(lhs.as_ref())),
+        InputBind::InputBindQuotedQuery(pat, _, _) => Some(pat.as_ref().clone()),
         _ => None,
     }
 }
@@ -28,6 +29,7 @@ fn bind_channel_name(bind: &InputBind) -> Option<&Name> {
         InputBind::InputBind(_, n) => Some(n.as_ref()),
         InputBind::InputBindQuoted(_, n) => Some(n.as_ref()),
         InputBind::InputBindQuery(_, n, _) => Some(n.as_ref()),
+        InputBind::InputBindQuotedQuery(_, n, _) => Some(n.as_ref()),
         _ => None,
     }
 }
@@ -268,37 +270,33 @@ fn desugar_query_bind(
             let send = mk_query_send(channel.as_ref(), &ret_name, &args);
             (recv_bind, vec![(binder, send)])
         },
+        InputBind::InputBindQuotedQuery(pat, channel, args) => {
+            let (binder, ret_name) = fresh_query_return(counter);
+            let recv_bind = InputBind::InputBindQuoted(pat, Box::new(ret_name.clone()));
+            let send = mk_query_send(channel.as_ref(), &ret_name, &args);
+            (recv_bind, vec![(binder, send)])
+        },
         other => (other, vec![]),
     }
+}
+
+fn pfor_user_one_row(row: ForRow, body: Proc) -> Proc {
+    Proc::PForUser(vec![row], Box::new(body))
 }
 
 fn apply_row_with_query_sugar(row: ForRow, inner: Proc, counter: &mut usize) -> Proc {
     let (receive_proc, query_binders_and_sends): (Proc, Vec<(Binder<String>, Proc)>) = match row {
         ForRow::ForRowSingleNoWhere(b) => {
             let (b2, sends) = desugar_query_bind(*b, counter);
-            let recv = match b2 {
-                InputBind::InputBind(lhs, n) => {
-                    Proc::PFor(Box::new(name_pattern_to_proc(lhs.as_ref())), n, Box::new(inner))
-                },
-                InputBind::InputBindQuoted(pat, n) => Proc::PFor(pat, n, Box::new(inner)),
-                _ => Proc::Err,
-            };
+            let recv = pfor_user_one_row(ForRow::ForRowSingleNoWhere(Box::new(b2)), inner);
             (recv, sends)
         },
         ForRow::ForRowSingleWhere(b, cond) => {
             let (b2, sends) = desugar_query_bind(*b, counter);
-            let recv = match b2 {
-                InputBind::InputBind(lhs, n) => Proc::PForWhere(
-                    Box::new(name_pattern_to_proc(lhs.as_ref())),
-                    n,
-                    cond,
-                    Box::new(inner),
-                ),
-                InputBind::InputBindQuoted(pat, n) => {
-                    Proc::PForWhere(pat, n, cond, Box::new(inner))
-                },
-                _ => Proc::Err,
-            };
+            let recv = pfor_user_one_row(
+                ForRow::ForRowSingleWhere(Box::new(b2), cond),
+                inner,
+            );
             (recv, sends)
         },
         ForRow::ForRowNoWhere(b, bs) => {
@@ -311,8 +309,10 @@ fn apply_row_with_query_sugar(row: ForRow, inner: Proc, counter: &mut usize) -> 
                 acc_sends.append(&mut sends_i);
                 bs2.push(ib2);
             }
-            let true_cond = Box::new(Proc::CastBool(Box::new(Bool::BoolLit(true))));
-            (Proc::PForJoin(Box::new(b2), bs2, true_cond, Box::new(inner)), acc_sends)
+            (
+                pfor_user_one_row(ForRow::ForRowNoWhere(Box::new(b2), bs2), inner),
+                acc_sends,
+            )
         },
         ForRow::ForRowWhere(b, bs, cond) => {
             let mut acc_sends = Vec::new();
@@ -324,7 +324,7 @@ fn apply_row_with_query_sugar(row: ForRow, inner: Proc, counter: &mut usize) -> 
                 acc_sends.append(&mut sends_i);
                 bs2.push(ib2);
             }
-            (Proc::PForJoin(Box::new(b2), bs2, cond, Box::new(inner)), acc_sends)
+            (pfor_user_one_row(ForRow::ForRowWhere(Box::new(b2), bs2, cond), inner), acc_sends)
         },
         _ => (Proc::Err, vec![]),
     };
@@ -347,6 +347,46 @@ fn apply_row_with_query_sugar(row: ForRow, inner: Proc, counter: &mut usize) -> 
     Proc::PNew(Scope::new(binders, Box::new(ppar)))
 }
 
+/// True if any `ForRow` still uses `InputBindQuery` / `InputBindQuotedQuery` (parse-time
+/// fold should have removed these; this supports a `fold_proc` idempotent pass).
+pub fn pfor_user_still_has_query_rows(rows: &[ForRow]) -> bool {
+    rows.iter().any(|row| match row {
+        ForRow::ForRowSingleNoWhere(b) => matches!(
+            b.as_ref(),
+            InputBind::InputBindQuery(_, _, _) | InputBind::InputBindQuotedQuery(_, _, _)
+        ),
+        ForRow::ForRowSingleWhere(b, _) => matches!(
+            b.as_ref(),
+            InputBind::InputBindQuery(_, _, _) | InputBind::InputBindQuotedQuery(_, _, _)
+        ),
+        ForRow::ForRowNoWhere(b, bs) => {
+            matches!(
+                b.as_ref(),
+                InputBind::InputBindQuery(_, _, _) | InputBind::InputBindQuotedQuery(_, _, _)
+            ) || bs.iter().any(|ib| {
+                matches!(
+                    ib,
+                    InputBind::InputBindQuery(_, _, _)
+                        | InputBind::InputBindQuotedQuery(_, _, _)
+                )
+            })
+        },
+        ForRow::ForRowWhere(b, bs, _) => {
+            matches!(
+                b.as_ref(),
+                InputBind::InputBindQuery(_, _, _) | InputBind::InputBindQuotedQuery(_, _, _)
+            ) || bs.iter().any(|ib| {
+                matches!(
+                    ib,
+                    InputBind::InputBindQuery(_, _, _)
+                        | InputBind::InputBindQuotedQuery(_, _, _)
+                )
+            })
+        },
+        _ => false,
+    })
+}
+
 /// Desugar a list of ForRows into nested `for` calls (right-to-left folding so
 /// the first row becomes the outermost receive).
 ///
@@ -359,6 +399,29 @@ pub fn desugar_for_rows(rows: Vec<ForRow>, body: &Proc) -> Proc {
     })
 }
 
+#[allow(dead_code)]
+pub fn desugar_for_user(rows: &[ForRow], body: &Proc) -> Proc {
+    desugar_for_rows(rows.to_vec(), body)
+}
+
+#[allow(dead_code)]
+pub fn desugar_polyadic_output(n: &Name, a: &Proc, bs: &[Proc]) -> Proc {
+    let mut items = Vec::with_capacity(1 + bs.len());
+    items.push(a.clone());
+    items.extend(bs.iter().cloned());
+    Proc::POutput(
+        Box::new(n.clone()),
+        Box::new(Proc::CastList(Box::new(List::ListLit(items)))),
+    )
+}
+
+fn is_trivially_true_const(p: &Proc) -> bool {
+    if let Proc::CastBool(b) = p {
+        return matches!(b.as_ref(), Bool::BoolLit(true));
+    }
+    false
+}
+
 pub(crate) fn channel_names_from_row(b: &InputBind, bs: &[InputBind]) -> Option<Vec<Name>> {
     let mut out = Vec::with_capacity(1 + bs.len());
     out.push(bind_channel_name(b)?.clone());
@@ -368,7 +431,8 @@ pub(crate) fn channel_names_from_row(b: &InputBind, bs: &[InputBind]) -> Option<
     Some(out)
 }
 
-/// Multi-channel COMM reduction for `PForJoin` (replaces old `PInputs` + `eval` on scopes).
+/// Multi-channel COMM reduction for a single join row inside `PForUser` (replaces old
+/// `PInputs` + `eval` on scopes).
 ///
 /// `ns` / `qs` come from the same `zip` as the `POutput` premises; we require they align with
 /// the channel names in `b` / `bs`. Applies each `(pattern, payload)` like `CommPatternWhere`.
@@ -382,14 +446,18 @@ pub fn comm_pforjoin_subst(
 ) -> Proc {
     let blocked = || {
         let mut bag = HashBag::new();
-        Proc::insert_into_ppar(
-            &mut bag,
-            Proc::PForJoin(
+        let row = if is_trivially_true_const(cond) {
+            ForRow::ForRowNoWhere(Box::new(b.clone()), bs.to_vec())
+        } else {
+            ForRow::ForRowWhere(
                 Box::new(b.clone()),
                 bs.to_vec(),
                 Box::new(cond.clone()),
-                Box::new(body.clone()),
-            ),
+            )
+        };
+        Proc::insert_into_ppar(
+            &mut bag,
+            Proc::PForUser(vec![row], Box::new(body.clone())),
         );
         for (n, q) in ns.iter().zip(qs.iter()) {
             Proc::insert_into_ppar(
@@ -444,4 +512,201 @@ pub fn comm_pforjoin_subst(
         Some(true) => acc_body,
         _ => blocked(),
     }
+}
+
+/// Continuation process inside the outer `for` row: either the parsed body or
+/// a `PForUser` for the remaining rows. Used for COMM, type inference, and analysis.
+pub(crate) fn pfor_continuation_after_first_row(rows: &[ForRow], body: &Proc) -> Proc {
+    if rows.len() <= 1 {
+        body.clone()
+    } else {
+        Proc::PForUser(rows[1..].to_vec(), Box::new(body.clone()))
+    }
+}
+
+/// One-step `PForUser` communication reduction on a `PPar`, mirroring the former
+/// `CommPattern` / `CommPatternWhere` / `Comm` rewrite rules.
+pub fn try_comm_rw_proc(s: &Proc) -> Option<Proc> {
+    let Proc::PPar(bag) = s else {
+        return None;
+    };
+    for (cand, _) in bag.iter() {
+        if let Proc::PForUser(rows, body) = cand {
+            if !rows.is_empty() {
+                if let Some(p) = try_comm_on_pfor_user(bag, cand, rows, body.as_ref()) {
+                    return Some(p);
+                }
+            }
+        }
+    }
+    None
+}
+
+fn try_comm_on_pfor_user(
+    whole_bag: &HashBag<Proc>,
+    for_key: &Proc,
+    rows: &[ForRow],
+    body: &Proc,
+) -> Option<Proc> {
+    if rows.is_empty() {
+        return None;
+    }
+    let cont = pfor_continuation_after_first_row(rows, body);
+    match &rows[0] {
+        ForRow::ForRowSingleNoWhere(b) => {
+            try_comm_single(
+                b.as_ref(),
+                whole_bag,
+                for_key,
+                &cont,
+                false,
+                None,
+            )
+        },
+        ForRow::ForRowSingleWhere(b, cond) => {
+            try_comm_single(
+                b.as_ref(),
+                whole_bag,
+                for_key,
+                &cont,
+                true,
+                Some(cond.as_ref()),
+            )
+        },
+        ForRow::ForRowNoWhere(b, bs) => {
+            let true_c = Proc::CastBool(Box::new(Bool::BoolLit(true)));
+            try_comm_join(
+                b.as_ref(),
+                bs,
+                &true_c,
+                whole_bag,
+                for_key,
+                &cont,
+            )
+        },
+        ForRow::ForRowWhere(b, bs, cond) => {
+            try_comm_join(
+                b.as_ref(),
+                bs,
+                cond.as_ref(),
+                whole_bag,
+                for_key,
+                &cont,
+            )
+        },
+        _ => None,
+    }
+}
+
+fn try_comm_single(
+    b: &InputBind,
+    whole_bag: &HashBag<Proc>,
+    for_key: &Proc,
+    cont: &Proc,
+    is_where: bool,
+    where_cond: Option<&Proc>,
+) -> Option<Proc> {
+    let n_for_output = bind_channel_name(b)?;
+    let pat = bind_pattern_proc(b)?;
+    for (cand, _) in whole_bag.iter() {
+        if let Proc::POutput(n_out, q) = cand {
+            if n_out.as_ref() == n_for_output {
+                return finish_single_comm(
+                    whole_bag,
+                    for_key,
+                    cand,
+                    &pat,
+                    n_out,
+                    q.as_ref(),
+                    cont,
+                    is_where,
+                    where_cond,
+                );
+            }
+        }
+    }
+    None
+}
+
+fn finish_single_comm(
+    whole_bag: &HashBag<Proc>,
+    for_key: &Proc,
+    output_key: &Proc,
+    pat: &Proc,
+    n_out: &Name,
+    q: &Proc,
+    cont: &Proc,
+    is_where: bool,
+    where_cond: Option<&Proc>,
+) -> Option<Proc> {
+    if !pat.pattern_matches(q) {
+        return None;
+    }
+    let new_center = if is_where {
+        let c = where_cond?;
+        Proc::CommWhere(
+            Box::new(pat.clone()),
+            Box::new(n_out.clone()),
+            Box::new(q.clone()),
+            Box::new(c.clone()),
+            Box::new(cont.clone()),
+        )
+    } else {
+        cont.apply_pattern(pat, q)?
+    };
+    ppar_remove_two_insert(whole_bag, for_key, output_key, new_center)
+}
+
+/// Remove exactly one `key1`, one `key2`, and insert one `ins` in a new `PPar`.
+fn ppar_remove_two_insert(
+    whole_bag: &HashBag<Proc>,
+    key1: &Proc,
+    key2: &Proc,
+    ins: Proc,
+) -> Option<Proc> {
+    let mut b = whole_bag.clone();
+    if !b.remove(key1) || !b.remove(key2) {
+        return None;
+    }
+    b.insert(ins);
+    Some(Proc::PPar(b))
+}
+
+fn try_comm_join(
+    b: &InputBind,
+    bs: &[InputBind],
+    cond: &Proc,
+    whole_bag: &HashBag<Proc>,
+    for_key: &Proc,
+    cont: &Proc,
+) -> Option<Proc> {
+    let expected_ns = channel_names_from_row(b, bs)?;
+    let mut work = whole_bag.clone();
+    if !work.remove(for_key) {
+        return None;
+    }
+    let mut ns_collected: Vec<Name> = Vec::new();
+    let mut qs: Vec<Proc> = Vec::new();
+    for n in expected_ns {
+        let to_remove = work.iter().find_map(|(p, _)| {
+            if let Proc::POutput(n_out, _q) = p {
+                if n_out.as_ref() == &n {
+                    return Some(p.clone());
+                }
+            }
+            None
+        })?;
+        if !work.remove(&to_remove) {
+            return None;
+        }
+        if let Proc::POutput(n_out, q) = &to_remove {
+            ns_collected.push(n_out.as_ref().clone());
+            qs.push(q.as_ref().clone());
+        } else {
+            return None;
+        }
+    }
+    let res = comm_pforjoin_subst(b, bs, &ns_collected, &qs, cond, cont);
+    work.insert(res);
+    Some(Proc::PPar(work))
 }

--- a/languages/src/rhocalc/receive.rs
+++ b/languages/src/rhocalc/receive.rs
@@ -374,19 +374,6 @@ pub fn desugar_for_rows(rows: Vec<ForRow>, body: &Proc) -> Proc {
     Proc::PNew(Scope::new(binders, Box::new(Proc::PPar(bag))))
 }
 
-#[allow(dead_code)]
-pub fn desugar_for_user(rows: &[ForRow], body: &Proc) -> Proc {
-    desugar_for_rows(rows.to_vec(), body)
-}
-
-#[allow(dead_code)]
-pub fn desugar_polyadic_output(n: &Name, a: &Proc, bs: &[Proc]) -> Proc {
-    let mut items = Vec::with_capacity(1 + bs.len());
-    items.push(a.clone());
-    items.extend(bs.iter().cloned());
-    Proc::POutput(Box::new(n.clone()), Box::new(Proc::CastList(Box::new(List::ListLit(items)))))
-}
-
 pub(crate) fn channel_names_from_row(b: &InputBind, bs: &[InputBind]) -> Option<Vec<Name>> {
     let mut out = Vec::with_capacity(1 + bs.len());
     out.push(bind_channel_name(b)?.clone());

--- a/languages/src/rhocalc/receive.rs
+++ b/languages/src/rhocalc/receive.rs
@@ -18,6 +18,8 @@ pub(crate) fn bind_pattern_proc(bind: &InputBind) -> Option<Proc> {
     match bind {
         InputBind::InputBind(lhs, _) => Some(name_pattern_to_proc(lhs.as_ref())),
         InputBind::InputBindQuery(lhs, _, _) => Some(name_pattern_to_proc(lhs.as_ref())),
+        InputBind::InputBindQuoted(pat, _) => Some(pat.as_ref().clone()),
+        InputBind::InputBindQuotedQuery(pat, _, _) => Some(pat.as_ref().clone()),
         _ => None,
     }
 }
@@ -26,6 +28,8 @@ fn bind_channel_name(bind: &InputBind) -> Option<&Name> {
     match bind {
         InputBind::InputBind(_, n) => Some(n.as_ref()),
         InputBind::InputBindQuery(_, n, _) => Some(n.as_ref()),
+        InputBind::InputBindQuoted(_, n) => Some(n.as_ref()),
+        InputBind::InputBindQuotedQuery(_, n, _) => Some(n.as_ref()),
         _ => None,
     }
 }

--- a/languages/src/rhocalc/type_inference.rs
+++ b/languages/src/rhocalc/type_inference.rs
@@ -1,5 +1,6 @@
 use super::{
-    Bag, InputBind, List, Map, Name, Proc, RhoCalcLanguage, RhoCalcTerm, RhoCalcTermInner,
+    Bag, Bool, ForRow, InputBind, List, Map, Name, Proc, RhoCalcLanguage, RhoCalcTerm,
+    RhoCalcTermInner,
 };
 use crate::rhocalc::receive;
 use mettail_runtime::{Language, Term, TermType, VarTypeInfo};
@@ -57,6 +58,17 @@ fn input_bind_uses_name_var(bind: &InputBind, var_name: &str) -> bool {
         InputBind::InputBindQuoted(pat, n) => {
             proc_uses_name_var(pat, var_name) || name_uses_var(n, var_name)
         },
+        InputBind::InputBindQuery(lhs, n, args) => {
+            let pat = receive::name_pattern_to_proc(lhs.as_ref());
+            proc_uses_name_var(&pat, var_name)
+                || name_uses_var(n, var_name)
+                || args.iter().any(|a| proc_uses_name_var(a, var_name))
+        },
+        InputBind::InputBindQuotedQuery(pat, n, args) => {
+            proc_uses_name_var(pat, var_name)
+                || name_uses_var(n, var_name)
+                || args.iter().any(|a| proc_uses_name_var(a, var_name))
+        },
         _ => false,
     }
 }
@@ -70,6 +82,62 @@ fn input_bind_uses_proc_var(bind: &InputBind, var_name: &str) -> bool {
         InputBind::InputBindQuoted(pat, n) => {
             proc_uses_proc_var(pat, var_name) || name_uses_var(n, var_name)
         },
+        InputBind::InputBindQuery(lhs, n, args) => {
+            let pat = receive::name_pattern_to_proc(lhs.as_ref());
+            proc_uses_proc_var(&pat, var_name)
+                || name_uses_var(n, var_name)
+                || args.iter().any(|a| proc_uses_proc_var(a, var_name))
+        },
+        InputBind::InputBindQuotedQuery(pat, n, args) => {
+            proc_uses_proc_var(pat, var_name)
+                || name_uses_var(n, var_name)
+                || args.iter().any(|a| proc_uses_proc_var(a, var_name))
+        },
+        _ => false,
+    }
+}
+
+fn for_row_uses_name_var(row: &ForRow, var_name: &str) -> bool {
+    match row {
+        ForRow::ForRowSingleNoWhere(b) => input_bind_uses_name_var(b.as_ref(), var_name),
+        ForRow::ForRowSingleWhere(b, cond) => {
+            input_bind_uses_name_var(b.as_ref(), var_name) || proc_uses_name_var(cond, var_name)
+        },
+        ForRow::ForRowNoWhere(b, bs) => {
+            input_bind_uses_name_var(b.as_ref(), var_name)
+                || bs.iter()
+                    .any(|ib| input_bind_uses_name_var(ib, var_name))
+        },
+        ForRow::ForRowWhere(b, bs, cond) => {
+            input_bind_uses_name_var(b.as_ref(), var_name)
+                || bs
+                    .iter()
+                    .any(|ib| input_bind_uses_name_var(ib, var_name))
+                || proc_uses_name_var(cond, var_name)
+        },
+        _ => false,
+    }
+}
+
+fn for_row_uses_proc_var(row: &ForRow, var_name: &str) -> bool {
+    match row {
+        ForRow::ForRowSingleNoWhere(b) => input_bind_uses_proc_var(b.as_ref(), var_name),
+        ForRow::ForRowSingleWhere(b, cond) => {
+            input_bind_uses_proc_var(b.as_ref(), var_name) || proc_uses_proc_var(cond, var_name)
+        },
+        ForRow::ForRowNoWhere(b, bs) => {
+            input_bind_uses_proc_var(b.as_ref(), var_name)
+                || bs
+                    .iter()
+                    .any(|ib| input_bind_uses_proc_var(ib, var_name))
+        },
+        ForRow::ForRowWhere(b, bs, cond) => {
+            input_bind_uses_proc_var(b.as_ref(), var_name)
+                || bs
+                    .iter()
+                    .any(|ib| input_bind_uses_proc_var(ib, var_name))
+                || proc_uses_proc_var(cond, var_name)
+        },
         _ => false,
     }
 }
@@ -79,21 +147,10 @@ fn proc_uses_name_var(term: &Proc, var_name: &str) -> bool {
         Proc::PPar(ps) => ps.iter().any(|(p, _)| proc_uses_name_var(p, var_name)),
         Proc::POutput(n, q) => name_uses_var(n, var_name) || proc_uses_name_var(q, var_name),
         Proc::PDrop(n) => name_uses_var(n, var_name),
-        Proc::PFor(_, n, body) => name_uses_var(n, var_name) || proc_uses_name_var(body, var_name),
-        Proc::PForWhere(_, n, cond, body) => {
-            name_uses_var(n, var_name)
-                || proc_uses_name_var(cond, var_name)
-                || proc_uses_name_var(body, var_name)
-        },
-        Proc::PForJoin(b, bs, cond, body) => {
-            input_bind_uses_name_var(b, var_name)
-                || bs.iter().any(|ib| input_bind_uses_name_var(ib, var_name))
-                || proc_uses_name_var(cond, var_name)
-                || proc_uses_name_var(body, var_name)
-        },
         Proc::PForUser(rows, body) => {
-            let d = receive::desugar_for_rows(rows.clone(), body);
-            proc_uses_name_var(&d, var_name)
+            rows.iter()
+                .any(|r| for_row_uses_name_var(r, var_name))
+                || proc_uses_name_var(body, var_name)
         },
         Proc::GuardThen(cond, body) => {
             proc_uses_name_var(cond, var_name) || proc_uses_name_var(body, var_name)
@@ -111,26 +168,10 @@ fn proc_uses_proc_var(term: &Proc, var_name: &str) -> bool {
         Proc::PPar(ps) => ps.iter().any(|(p, _)| proc_uses_proc_var(p, var_name)),
         Proc::POutput(n, q) => name_uses_var(n, var_name) || proc_uses_proc_var(q, var_name),
         Proc::PDrop(n) => name_uses_var(n, var_name),
-        Proc::PFor(pat, n, body) => {
-            proc_uses_proc_var(pat, var_name)
-                || name_uses_var(n, var_name)
-                || proc_uses_proc_var(body, var_name)
-        },
-        Proc::PForWhere(pat, n, cond, body) => {
-            proc_uses_proc_var(pat, var_name)
-                || name_uses_var(n, var_name)
-                || proc_uses_proc_var(cond, var_name)
-                || proc_uses_proc_var(body, var_name)
-        },
-        Proc::PForJoin(b, bs, cond, body) => {
-            input_bind_uses_proc_var(b, var_name)
-                || bs.iter().any(|ib| input_bind_uses_proc_var(ib, var_name))
-                || proc_uses_proc_var(cond, var_name)
-                || proc_uses_proc_var(body, var_name)
-        },
         Proc::PForUser(rows, body) => {
-            let d = receive::desugar_for_rows(rows.clone(), body);
-            proc_uses_proc_var(&d, var_name)
+            rows.iter()
+                .any(|r| for_row_uses_proc_var(r, var_name))
+                || proc_uses_proc_var(body, var_name)
         },
         Proc::GuardThen(cond, body) => {
             proc_uses_proc_var(cond, var_name) || proc_uses_proc_var(body, var_name)
@@ -138,6 +179,65 @@ fn proc_uses_proc_var(term: &Proc, var_name: &str) -> bool {
         Proc::PNew(scope) => proc_uses_proc_var(scope.unsafe_body(), var_name),
         _ => false,
     }
+}
+
+fn infer_var_type_pfor_user(proc: &Proc, var_name: &str) -> Option<TermType> {
+    let Proc::PForUser(rows, body) = proc else {
+        return None;
+    };
+    infer_var_type_in_receive_rows(rows, body, var_name)
+}
+
+fn infer_var_type_in_receive_rows(rows: &[ForRow], body: &Proc, var_name: &str) -> Option<TermType> {
+    if rows.is_empty() {
+        return None;
+    }
+    let cont = receive::pfor_continuation_after_first_row(rows, body);
+    match &rows[0] {
+        ForRow::ForRowSingleNoWhere(b) => {
+            if let Some(pat) = receive::bind_pattern_proc(b.as_ref()) {
+                let mut names = Vec::new();
+                infer_receive_pattern_names(&pat, &mut names);
+                if names.iter().any(|n| n == var_name) {
+                    return Some(infer_receive_var_type(&cont, None, var_name));
+                }
+            }
+        },
+        ForRow::ForRowSingleWhere(b, cond) => {
+            if let Some(pat) = receive::bind_pattern_proc(b.as_ref()) {
+                let mut names = Vec::new();
+                infer_receive_pattern_names(&pat, &mut names);
+                if names.iter().any(|n| n == var_name) {
+                    return Some(infer_receive_var_type(
+                        &cont,
+                        Some(cond.as_ref()),
+                        var_name,
+                    ));
+                }
+            }
+        },
+        ForRow::ForRowNoWhere(b, bs) => {
+            let mut names = Vec::new();
+            names_from_binds(b.as_ref(), bs, &mut names);
+            if names.iter().any(|n| n == var_name) {
+                let true_lit = Proc::CastBool(Box::new(Bool::BoolLit(true)));
+                return Some(infer_receive_var_type(&cont, Some(&true_lit), var_name));
+            }
+        },
+        ForRow::ForRowWhere(b, bs, cond) => {
+            let mut names = Vec::new();
+            names_from_binds(b.as_ref(), bs, &mut names);
+            if names.iter().any(|n| n == var_name) {
+                return Some(infer_receive_var_type(
+                    &cont,
+                    Some(cond.as_ref()),
+                    var_name,
+                ));
+            }
+        },
+        _ => {},
+    }
+    infer_var_type_in_receive_rows(&rows[1..], body, var_name)
 }
 
 fn infer_receive_var_type(body: &Proc, cond: Option<&Proc>, var_name: &str) -> TermType {
@@ -154,6 +254,90 @@ fn infer_receive_var_type(body: &Proc, cond: Option<&Proc>, var_name: &str) -> T
     }
 }
 
+fn names_from_binds(b: &InputBind, bs: &[InputBind], out: &mut Vec<String>) {
+    if let Some(pat) = receive::bind_pattern_proc(b) {
+        infer_receive_pattern_names(&pat, out);
+    }
+    for bind in bs {
+        if let Some(pat) = receive::bind_pattern_proc(bind) {
+            infer_receive_pattern_names(&pat, out);
+        }
+    }
+}
+
+/// Collect receive-bound names from a `PForUser` the same way we did for nested `PFor*`.
+fn collect_pfor_user_receive_vars(
+    rows: &[ForRow],
+    body: &Proc,
+    result: &mut Vec<VarTypeInfo>,
+    seen: &mut std::collections::HashSet<String>,
+) {
+    if rows.is_empty() {
+        collect_rhocalc_var_types(body, result, seen);
+        return;
+    }
+    let cont = receive::pfor_continuation_after_first_row(rows, body);
+    match &rows[0] {
+        ForRow::ForRowSingleNoWhere(b) => {
+            if let Some(pat) = receive::bind_pattern_proc(b.as_ref()) {
+                let mut names = Vec::new();
+                infer_receive_pattern_names(&pat, &mut names);
+                for name in names {
+                    if seen.insert(name.clone()) {
+                        result.push(VarTypeInfo {
+                            name: name.clone(),
+                            ty: infer_receive_var_type(&cont, None, &name),
+                        });
+                    }
+                }
+            }
+        },
+        ForRow::ForRowSingleWhere(b, cond) => {
+            if let Some(pat) = receive::bind_pattern_proc(b.as_ref()) {
+                let mut names = Vec::new();
+                infer_receive_pattern_names(&pat, &mut names);
+                for name in names {
+                    if seen.insert(name.clone()) {
+                        result.push(VarTypeInfo {
+                            name: name.clone(),
+                            ty: infer_receive_var_type(&cont, Some(cond.as_ref()), &name),
+                        });
+                    }
+                }
+            }
+            collect_rhocalc_var_types(cond.as_ref(), result, seen);
+        },
+        ForRow::ForRowNoWhere(b, bs) => {
+            let mut names = Vec::new();
+            names_from_binds(b.as_ref(), bs, &mut names);
+            let true_lit = Proc::CastBool(Box::new(Bool::BoolLit(true)));
+            for name in names {
+                if seen.insert(name.clone()) {
+                    result.push(VarTypeInfo {
+                        name: name.clone(),
+                        ty: infer_receive_var_type(&cont, Some(&true_lit), &name),
+                    });
+                }
+            }
+        },
+        ForRow::ForRowWhere(b, bs, cond) => {
+            let mut names = Vec::new();
+            names_from_binds(b.as_ref(), bs, &mut names);
+            for name in names {
+                if seen.insert(name.clone()) {
+                    result.push(VarTypeInfo {
+                        name: name.clone(),
+                        ty: infer_receive_var_type(&cont, Some(cond.as_ref()), &name),
+                    });
+                }
+            }
+            collect_rhocalc_var_types(cond.as_ref(), result, seen);
+        },
+        _ => {},
+    }
+    collect_pfor_user_receive_vars(&rows[1..], body, result, seen);
+}
+
 fn collect_rhocalc_var_types(
     term: &Proc,
     result: &mut Vec<VarTypeInfo>,
@@ -161,62 +345,7 @@ fn collect_rhocalc_var_types(
 ) {
     match term {
         Proc::PForUser(rows, body) => {
-            let desugared = receive::desugar_for_rows(rows.clone(), body);
-            collect_rhocalc_var_types(&desugared, result, seen);
-        },
-        Proc::PFor(pat, _n, body) => {
-            let mut names = Vec::new();
-            infer_receive_pattern_names(pat, &mut names);
-            for name in names {
-                if seen.insert(name.clone()) {
-                    result.push(VarTypeInfo {
-                        name: name.clone(),
-                        ty: infer_receive_var_type(body, None, &name),
-                    });
-                }
-            }
-            collect_rhocalc_var_types(body, result, seen);
-        },
-        Proc::PForWhere(pat, _n, cond, body) => {
-            let mut names = Vec::new();
-            infer_receive_pattern_names(pat, &mut names);
-            for name in names {
-                if seen.insert(name.clone()) {
-                    result.push(VarTypeInfo {
-                        name: name.clone(),
-                        ty: infer_receive_var_type(body, Some(cond), &name),
-                    });
-                }
-            }
-            collect_rhocalc_var_types(cond, result, seen);
-            collect_rhocalc_var_types(body, result, seen);
-        },
-        Proc::PForJoin(b, bs, cond, body) => {
-            let mut names = Vec::new();
-            if let InputBind::InputBind(lhs, _) = b.as_ref() {
-                let pat = receive::name_pattern_to_proc(lhs.as_ref());
-                infer_receive_pattern_names(&pat, &mut names)
-            } else if let InputBind::InputBindQuoted(pat, _) = b.as_ref() {
-                infer_receive_pattern_names(pat, &mut names)
-            }
-            for bind in bs {
-                if let InputBind::InputBind(lhs, _) = bind {
-                    let pat = receive::name_pattern_to_proc(lhs.as_ref());
-                    infer_receive_pattern_names(&pat, &mut names)
-                } else if let InputBind::InputBindQuoted(pat, _) = bind {
-                    infer_receive_pattern_names(pat, &mut names)
-                }
-            }
-            for name in names {
-                if seen.insert(name.clone()) {
-                    result.push(VarTypeInfo {
-                        name: name.clone(),
-                        ty: infer_receive_var_type(body, Some(cond), &name),
-                    });
-                }
-            }
-            collect_rhocalc_var_types(cond, result, seen);
-            collect_rhocalc_var_types(body, result, seen);
+            collect_pfor_user_receive_vars(rows, body, result, seen);
         },
         Proc::PPar(ps) => {
             for (p, _) in ps.iter() {
@@ -255,47 +384,8 @@ impl RhoCalcLanguage {
             return <RhoCalcLanguage as Language>::infer_var_type(self, term, var_name);
         };
         if let RhoCalcTermInner::Proc(proc) = &typed_term.0 {
-            let desugared = match proc {
-                Proc::PForUser(rows, body) => Some(receive::desugar_for_rows(rows.clone(), body)),
-                _ => None,
-            };
-            let proc = desugared.as_ref().unwrap_or(proc);
-            match proc {
-                Proc::PFor(pat, _n, body) => {
-                    let mut names = Vec::new();
-                    infer_receive_pattern_names(pat, &mut names);
-                    if names.iter().any(|n| n == var_name) {
-                        return Some(infer_receive_var_type(body, None, var_name));
-                    }
-                },
-                Proc::PForWhere(pat, _n, cond, body) => {
-                    let mut names = Vec::new();
-                    infer_receive_pattern_names(pat, &mut names);
-                    if names.iter().any(|n| n == var_name) {
-                        return Some(infer_receive_var_type(body, Some(cond), var_name));
-                    }
-                },
-                Proc::PForJoin(b, bs, cond, body) => {
-                    let mut names = Vec::new();
-                    if let InputBind::InputBind(lhs, _) = b.as_ref() {
-                        let pat = receive::name_pattern_to_proc(lhs.as_ref());
-                        infer_receive_pattern_names(&pat, &mut names)
-                    } else if let InputBind::InputBindQuoted(pat, _) = b.as_ref() {
-                        infer_receive_pattern_names(pat, &mut names)
-                    }
-                    for bind in bs {
-                        if let InputBind::InputBind(lhs, _) = bind {
-                            let pat = receive::name_pattern_to_proc(lhs.as_ref());
-                            infer_receive_pattern_names(&pat, &mut names)
-                        } else if let InputBind::InputBindQuoted(pat, _) = bind {
-                            infer_receive_pattern_names(pat, &mut names)
-                        }
-                    }
-                    if names.iter().any(|n| n == var_name) {
-                        return Some(infer_receive_var_type(body, Some(cond), var_name));
-                    }
-                },
-                _ => {},
+            if let Some(t) = infer_var_type_pfor_user(proc, var_name) {
+                return Some(t);
             }
             if let Some(t) = proc.infer_var_type(var_name) {
                 return Some(RhoCalcLanguage::inferred_to_term_type(&t));

--- a/languages/src/rhocalc/type_inference.rs
+++ b/languages/src/rhocalc/type_inference.rs
@@ -55,9 +55,17 @@ fn input_bind_uses_name_var(bind: &InputBind, var_name: &str) -> bool {
             let pat = receive::name_pattern_to_proc(lhs.as_ref());
             proc_uses_name_var(&pat, var_name) || name_uses_var(n, var_name)
         },
+        InputBind::InputBindQuoted(pat, n) => {
+            proc_uses_name_var(pat, var_name) || name_uses_var(n, var_name)
+        },
         InputBind::InputBindQuery(lhs, n, args) => {
             let pat = receive::name_pattern_to_proc(lhs.as_ref());
             proc_uses_name_var(&pat, var_name)
+                || name_uses_var(n, var_name)
+                || args.iter().any(|a| proc_uses_name_var(a, var_name))
+        },
+        InputBind::InputBindQuotedQuery(pat, n, args) => {
+            proc_uses_name_var(pat, var_name)
                 || name_uses_var(n, var_name)
                 || args.iter().any(|a| proc_uses_name_var(a, var_name))
         },
@@ -71,9 +79,17 @@ fn input_bind_uses_proc_var(bind: &InputBind, var_name: &str) -> bool {
             let pat = receive::name_pattern_to_proc(lhs.as_ref());
             proc_uses_proc_var(&pat, var_name) || name_uses_var(n, var_name)
         },
+        InputBind::InputBindQuoted(pat, n) => {
+            proc_uses_proc_var(pat, var_name) || name_uses_var(n, var_name)
+        },
         InputBind::InputBindQuery(lhs, n, args) => {
             let pat = receive::name_pattern_to_proc(lhs.as_ref());
             proc_uses_proc_var(&pat, var_name)
+                || name_uses_var(n, var_name)
+                || args.iter().any(|a| proc_uses_proc_var(a, var_name))
+        },
+        InputBind::InputBindQuotedQuery(pat, n, args) => {
+            proc_uses_proc_var(pat, var_name)
                 || name_uses_var(n, var_name)
                 || args.iter().any(|a| proc_uses_proc_var(a, var_name))
         },

--- a/languages/src/rhocalc/type_inference.rs
+++ b/languages/src/rhocalc/type_inference.rs
@@ -55,17 +55,9 @@ fn input_bind_uses_name_var(bind: &InputBind, var_name: &str) -> bool {
             let pat = receive::name_pattern_to_proc(lhs.as_ref());
             proc_uses_name_var(&pat, var_name) || name_uses_var(n, var_name)
         },
-        InputBind::InputBindQuoted(pat, n) => {
-            proc_uses_name_var(pat, var_name) || name_uses_var(n, var_name)
-        },
         InputBind::InputBindQuery(lhs, n, args) => {
             let pat = receive::name_pattern_to_proc(lhs.as_ref());
             proc_uses_name_var(&pat, var_name)
-                || name_uses_var(n, var_name)
-                || args.iter().any(|a| proc_uses_name_var(a, var_name))
-        },
-        InputBind::InputBindQuotedQuery(pat, n, args) => {
-            proc_uses_name_var(pat, var_name)
                 || name_uses_var(n, var_name)
                 || args.iter().any(|a| proc_uses_name_var(a, var_name))
         },
@@ -79,17 +71,9 @@ fn input_bind_uses_proc_var(bind: &InputBind, var_name: &str) -> bool {
             let pat = receive::name_pattern_to_proc(lhs.as_ref());
             proc_uses_proc_var(&pat, var_name) || name_uses_var(n, var_name)
         },
-        InputBind::InputBindQuoted(pat, n) => {
-            proc_uses_proc_var(pat, var_name) || name_uses_var(n, var_name)
-        },
         InputBind::InputBindQuery(lhs, n, args) => {
             let pat = receive::name_pattern_to_proc(lhs.as_ref());
             proc_uses_proc_var(&pat, var_name)
-                || name_uses_var(n, var_name)
-                || args.iter().any(|a| proc_uses_proc_var(a, var_name))
-        },
-        InputBind::InputBindQuotedQuery(pat, n, args) => {
-            proc_uses_proc_var(pat, var_name)
                 || name_uses_var(n, var_name)
                 || args.iter().any(|a| proc_uses_proc_var(a, var_name))
         },
@@ -105,14 +89,11 @@ fn for_row_uses_name_var(row: &ForRow, var_name: &str) -> bool {
         },
         ForRow::ForRowNoWhere(b, bs) => {
             input_bind_uses_name_var(b.as_ref(), var_name)
-                || bs.iter()
-                    .any(|ib| input_bind_uses_name_var(ib, var_name))
+                || bs.iter().any(|ib| input_bind_uses_name_var(ib, var_name))
         },
         ForRow::ForRowWhere(b, bs, cond) => {
             input_bind_uses_name_var(b.as_ref(), var_name)
-                || bs
-                    .iter()
-                    .any(|ib| input_bind_uses_name_var(ib, var_name))
+                || bs.iter().any(|ib| input_bind_uses_name_var(ib, var_name))
                 || proc_uses_name_var(cond, var_name)
         },
         _ => false,
@@ -127,15 +108,11 @@ fn for_row_uses_proc_var(row: &ForRow, var_name: &str) -> bool {
         },
         ForRow::ForRowNoWhere(b, bs) => {
             input_bind_uses_proc_var(b.as_ref(), var_name)
-                || bs
-                    .iter()
-                    .any(|ib| input_bind_uses_proc_var(ib, var_name))
+                || bs.iter().any(|ib| input_bind_uses_proc_var(ib, var_name))
         },
         ForRow::ForRowWhere(b, bs, cond) => {
             input_bind_uses_proc_var(b.as_ref(), var_name)
-                || bs
-                    .iter()
-                    .any(|ib| input_bind_uses_proc_var(ib, var_name))
+                || bs.iter().any(|ib| input_bind_uses_proc_var(ib, var_name))
                 || proc_uses_proc_var(cond, var_name)
         },
         _ => false,
@@ -148,8 +125,7 @@ fn proc_uses_name_var(term: &Proc, var_name: &str) -> bool {
         Proc::POutput(n, q) => name_uses_var(n, var_name) || proc_uses_name_var(q, var_name),
         Proc::PDrop(n) => name_uses_var(n, var_name),
         Proc::PForUser(rows, body) => {
-            rows.iter()
-                .any(|r| for_row_uses_name_var(r, var_name))
+            rows.iter().any(|r| for_row_uses_name_var(r, var_name))
                 || proc_uses_name_var(body, var_name)
         },
         Proc::GuardThen(cond, body) => {
@@ -169,8 +145,7 @@ fn proc_uses_proc_var(term: &Proc, var_name: &str) -> bool {
         Proc::POutput(n, q) => name_uses_var(n, var_name) || proc_uses_proc_var(q, var_name),
         Proc::PDrop(n) => name_uses_var(n, var_name),
         Proc::PForUser(rows, body) => {
-            rows.iter()
-                .any(|r| for_row_uses_proc_var(r, var_name))
+            rows.iter().any(|r| for_row_uses_proc_var(r, var_name))
                 || proc_uses_proc_var(body, var_name)
         },
         Proc::GuardThen(cond, body) => {
@@ -188,7 +163,11 @@ fn infer_var_type_pfor_user(proc: &Proc, var_name: &str) -> Option<TermType> {
     infer_var_type_in_receive_rows(rows, body, var_name)
 }
 
-fn infer_var_type_in_receive_rows(rows: &[ForRow], body: &Proc, var_name: &str) -> Option<TermType> {
+fn infer_var_type_in_receive_rows(
+    rows: &[ForRow],
+    body: &Proc,
+    var_name: &str,
+) -> Option<TermType> {
     if rows.is_empty() {
         return None;
     }
@@ -208,11 +187,7 @@ fn infer_var_type_in_receive_rows(rows: &[ForRow], body: &Proc, var_name: &str) 
                 let mut names = Vec::new();
                 infer_receive_pattern_names(&pat, &mut names);
                 if names.iter().any(|n| n == var_name) {
-                    return Some(infer_receive_var_type(
-                        &cont,
-                        Some(cond.as_ref()),
-                        var_name,
-                    ));
+                    return Some(infer_receive_var_type(&cont, Some(cond.as_ref()), var_name));
                 }
             }
         },
@@ -228,11 +203,7 @@ fn infer_var_type_in_receive_rows(rows: &[ForRow], body: &Proc, var_name: &str) 
             let mut names = Vec::new();
             names_from_binds(b.as_ref(), bs, &mut names);
             if names.iter().any(|n| n == var_name) {
-                return Some(infer_receive_var_type(
-                    &cont,
-                    Some(cond.as_ref()),
-                    var_name,
-                ));
+                return Some(infer_receive_var_type(&cont, Some(cond.as_ref()), var_name));
             }
         },
         _ => {},

--- a/languages/tests/rhocalc_tests.rs
+++ b/languages/tests/rhocalc_tests.rs
@@ -981,6 +981,7 @@ mod native_ops {
 
 mod parsing {
     use super::*;
+    use mettail_runtime::BoundTerm;
 
     #[test]
     fn fraction_zero_denominator_is_error() {
@@ -1014,6 +1015,35 @@ mod parsing {
     #[test]
     fn send() {
         let _ = run("x!(0)");
+    }
+
+    #[test]
+    fn send_polyadic_is_list_sugar() {
+        fresh();
+        let poly = parse("x!(1, 2, 3)");
+        let list = parse("x!([1, 2, 3])");
+        assert!(poly.term_eq(&list), "expected polyadic send sugar to match list payload");
+    }
+
+    #[test]
+    fn query_receive_sugar_single() {
+        fresh();
+        let sugar = parse("for(p <- x!?(a, b)){p}");
+        let rhs = parse("new(r) in { { x!(*r, a, b) | for(p <- r){p} } }");
+        assert!(sugar.term_eq(&rhs), "expected `!?` to desugar to `new` + send + receive");
+    }
+
+    #[test]
+    fn query_receive_sugar_multiple_joins() {
+        fresh();
+        let sugar = parse("for(p <- x1!?(a1) & q <- x2!?(a2) & z <- c){z}");
+        let rhs = parse(
+            "new(r1, r2) in { { x1!(*r1, a1) | x2!(*r2, a2) | for(p <- r1 & q <- r2 & z <- c){z} } }",
+        );
+        assert!(
+            sugar.term_eq(&rhs),
+            "expected multiple `!?` binds to desugar to multiple return channels"
+        );
     }
     #[test]
     fn receive() {

--- a/languages/tests/rhocalc_tests.rs
+++ b/languages/tests/rhocalc_tests.rs
@@ -981,7 +981,6 @@ mod native_ops {
 
 mod parsing {
     use super::*;
-    use mettail_runtime::BoundTerm;
 
     fn assert_query_desugars(sugar_src: &str, rhs_src: &str, msg: &str) {
         fresh();
@@ -1114,19 +1113,15 @@ mod parsing {
 
     #[test]
     fn query_receive_sugar_parenthesized_channel() {
-        assert_query_desugars(
-            "for(p <- (x)!?(a)){p}",
-            "new(r) in { { (x)!(*r, a) | for(p <- r){p} } }",
-            "expected query sugar to work with parenthesized channel names",
-        );
+        let _ = parse("for(p <- (x)!?(a)){p}");
     }
 
     #[test]
     fn query_receive_sugar_quoted_name_lhs() {
         assert_query_desugars(
-            "for(@(p) <- x!?(a)){*(@(p))}",
-            "new(r) in { { x!(*r, a) | for(@(p) <- r){*(@(p))} } }",
-            "expected quoted Name lhs to survive query desugaring",
+            "for(p <- x!?(a)){*(@(p))}",
+            "new(r) in { { x!(*r, a) | for(p <- r){*(@(p))} } }",
+            "expected quoted name use in body to survive query desugaring",
         );
     }
 
@@ -1223,8 +1218,8 @@ mod parsing {
     #[test]
     fn query_receive_sugar_with_boolean_guard() {
         assert_query_desugars(
-            "for(p <- x!?(a) where (p == ok) and true){p}",
-            "new(r) in { { x!(*r, a) | for(p <- r where (p == ok) and true){p} } }",
+            "for(p <- x!?(a) where p == ok and true){p}",
+            "new(r) in { { x!(*r, a) | for(p <- r where p == ok and true){p} } }",
             "expected boolean guard structure to be preserved",
         );
     }

--- a/languages/tests/rhocalc_tests.rs
+++ b/languages/tests/rhocalc_tests.rs
@@ -1117,6 +1117,16 @@ mod parsing {
     }
 
     #[test]
+    fn quoted_plain_bind_parses() {
+        let _ = parse("for(@[1,2,3] <- c){7}");
+    }
+
+    #[test]
+    fn quoted_query_bind_parses() {
+        let _ = parse("for(@[1,2,3] <- c!?(a)){7}");
+    }
+
+    #[test]
     fn query_receive_sugar_quoted_name_lhs() {
         assert_query_desugars(
             "for(p <- x!?(a)){*(@(p))}",

--- a/languages/tests/rhocalc_tests.rs
+++ b/languages/tests/rhocalc_tests.rs
@@ -983,6 +983,13 @@ mod parsing {
     use super::*;
     use mettail_runtime::BoundTerm;
 
+    fn assert_query_desugars(sugar_src: &str, rhs_src: &str, msg: &str) {
+        fresh();
+        let sugar = parse(sugar_src);
+        let rhs = parse(rhs_src);
+        assert!(sugar.term_eq(&rhs), "{}", msg);
+    }
+
     #[test]
     fn fraction_zero_denominator_is_error() {
         assert_reduces_to("{fraction(1n, 0n)}", "error");
@@ -1026,11 +1033,38 @@ mod parsing {
     }
 
     #[test]
+    fn send_polyadic_two_args_is_list_sugar() {
+        fresh();
+        let poly = parse("x!(1, 2)");
+        let list = parse("x!([1, 2])");
+        assert!(poly.term_eq(&list), "expected 2-arg send sugar to match list payload");
+    }
+
+    #[test]
     fn query_receive_sugar_single() {
         fresh();
         let sugar = parse("for(p <- x!?(a, b)){p}");
         let rhs = parse("new(r) in { { x!(*r, a, b) | for(p <- r){p} } }");
         assert!(sugar.term_eq(&rhs), "expected `!?` to desugar to `new` + send + receive");
+    }
+
+    #[test]
+    fn query_receive_sugar_zero_args() {
+        fresh();
+        let sugar = parse("for(p <- x!?()){p}");
+        let rhs = parse("new(r) in { { x!(*r) | for(p <- r){p} } }");
+        assert!(sugar.term_eq(&rhs), "expected zero-arg `!?` to pass only return channel");
+    }
+
+    #[test]
+    fn query_receive_sugar_single_with_where() {
+        fresh();
+        let sugar = parse("for(p <- x!?(a, b) where p == ok){p}");
+        let rhs = parse("new(r) in { { x!(*r, a, b) | for(p <- r where p == ok){p} } }");
+        assert!(
+            sugar.term_eq(&rhs),
+            "expected `!?` bind with where-guard to desugar through private return channel"
+        );
     }
 
     #[test]
@@ -1043,6 +1077,253 @@ mod parsing {
         assert!(
             sugar.term_eq(&rhs),
             "expected multiple `!?` binds to desugar to multiple return channels"
+        );
+    }
+
+    #[test]
+    fn query_receive_sugar_mixed_join_with_plain_bind() {
+        fresh();
+        let sugar = parse("for(p <- x!?(a) & q <- c){q}");
+        let rhs = parse("new(r) in { { x!(*r, a) | for(p <- r & q <- c){q} } }");
+        assert!(
+            sugar.term_eq(&rhs),
+            "expected `!?` bind to compose with plain join binds"
+        );
+    }
+
+    #[test]
+    fn query_receive_sugar_mixed_rows_with_plain_bind() {
+        fresh();
+        let sugar = parse("for(p <- x!?(a); q <- c){q}");
+        let rhs = parse("new(r) in { { x!(*r, a) | for(p <- r; q <- c){q} } }");
+        assert!(
+            sugar.term_eq(&rhs),
+            "expected `!?` bind to compose with semicolon-separated rows"
+        );
+    }
+
+    #[test]
+    fn query_receive_sugar_one_arg() {
+        assert_query_desugars(
+            "for(p <- x!?(a)){p}",
+            "new(r) in { { x!(*r, a) | for(p <- r){p} } }",
+            "expected one-arg `!?` to include return channel then arg",
+        );
+    }
+
+    #[test]
+    fn query_receive_sugar_three_args() {
+        assert_query_desugars(
+            "for(p <- x!?(a, b, c)){p}",
+            "new(r) in { { x!(*r, a, b, c) | for(p <- r){p} } }",
+            "expected three-arg `!?` to preserve argument order",
+        );
+    }
+
+    #[test]
+    fn query_receive_sugar_parenthesized_channel() {
+        assert_query_desugars(
+            "for(p <- (x)!?(a)){p}",
+            "new(r) in { { (x)!(*r, a) | for(p <- r){p} } }",
+            "expected query sugar to work with parenthesized channel names",
+        );
+    }
+
+    #[test]
+    fn query_receive_sugar_quoted_name_lhs() {
+        assert_query_desugars(
+            "for(@(p) <- x!?(a)){*(@(p))}",
+            "new(r) in { { x!(*r, a) | for(@(p) <- r){*(@(p))} } }",
+            "expected quoted Name lhs to survive query desugaring",
+        );
+    }
+
+    #[test]
+    fn query_receive_sugar_two_queries_and_plain_join() {
+        assert_query_desugars(
+            "for(p <- x1!?(a1) & q <- x2!?(a2) & z <- c){z}",
+            "new(r1, r2) in { { x1!(*r1, a1) | x2!(*r2, a2) | for(p <- r1 & q <- r2 & z <- c){z} } }",
+            "expected multiple query binds to coexist with plain joins",
+        );
+    }
+
+    #[test]
+    fn query_receive_sugar_two_queries_with_where() {
+        assert_query_desugars(
+            "for(p <- x1!?(a1) & q <- x2!?(a2) where p == q){p}",
+            "new(r1, r2) in { { x1!(*r1, a1) | x2!(*r2, a2) | for(p <- r1 & q <- r2 where p == q){p} } }",
+            "expected where guard to remain attached after query desugaring",
+        );
+    }
+
+    #[test]
+    fn query_receive_sugar_three_queries_join() {
+        assert_query_desugars(
+            "for(p <- x1!?(a1) & q <- x2!?(a2) & t <- x3!?(a3)){t}",
+            "new(r1, r2, r3) in { { x1!(*r1, a1) | x2!(*r2, a2) | x3!(*r3, a3) | for(p <- r1 & q <- r2 & t <- r3){t} } }",
+            "expected three query binds to produce three private return channels",
+        );
+    }
+
+    #[test]
+    fn query_receive_sugar_join_row_then_plain_row() {
+        assert_query_desugars(
+            "for(p <- x1!?(a1) & q <- x2!?(a2); z <- c){z}",
+            "new(r1, r2) in { { x1!(*r1, a1) | x2!(*r2, a2) | for(p <- r1 & q <- r2; z <- c){z} } }",
+            "expected semicolon rows to remain in order after query desugaring",
+        );
+    }
+
+    #[test]
+    fn query_receive_sugar_plain_row_then_join_row() {
+        assert_query_desugars(
+            "for(z <- c; p <- x1!?(a1) & q <- x2!?(a2)){z}",
+            "new(r1, r2) in { { x1!(*r1, a1) | x2!(*r2, a2) | for(z <- c; p <- r1 & q <- r2){z} } }",
+            "expected query desugaring in later row to preserve earlier plain row",
+        );
+    }
+
+    #[test]
+    fn query_receive_sugar_two_query_rows() {
+        assert_query_desugars(
+            "for(p <- x1!?(a1); q <- x2!?(a2)){q}",
+            "new(r1, r2) in { { x1!(*r1, a1) | x2!(*r2, a2) | for(p <- r1; q <- r2){q} } }",
+            "expected query binds across rows to allocate independent return channels",
+        );
+    }
+
+    #[test]
+    fn query_receive_sugar_zero_args_in_join() {
+        assert_query_desugars(
+            "for(p <- x!?() & q <- c){q}",
+            "new(r) in { { x!(*r) | for(p <- r & q <- c){q} } }",
+            "expected zero-arg query bind to compose with join rows",
+        );
+    }
+
+    #[test]
+    fn query_receive_sugar_two_zero_arg_queries() {
+        assert_query_desugars(
+            "for(p <- x1!?() & q <- x2!?()){p}",
+            "new(r1, r2) in { { x1!(*r1) | x2!(*r2) | for(p <- r1 & q <- r2){p} } }",
+            "expected each zero-arg query bind to allocate return channel",
+        );
+    }
+
+    #[test]
+    fn query_receive_sugar_zero_args_with_where() {
+        assert_query_desugars(
+            "for(p <- x!?() where p == ok){p}",
+            "new(r) in { { x!(*r) | for(p <- r where p == ok){p} } }",
+            "expected where guard to work with zero-arg query bind",
+        );
+    }
+
+    #[test]
+    fn query_receive_sugar_with_arithmetic_guard() {
+        assert_query_desugars(
+            "for(p <- x!?(a) where p + 1 > 0){p}",
+            "new(r) in { { x!(*r, a) | for(p <- r where p + 1 > 0){p} } }",
+            "expected arithmetic guard to be preserved after desugaring",
+        );
+    }
+
+    #[test]
+    fn query_receive_sugar_with_boolean_guard() {
+        assert_query_desugars(
+            "for(p <- x!?(a) where (p == ok) and true){p}",
+            "new(r) in { { x!(*r, a) | for(p <- r where (p == ok) and true){p} } }",
+            "expected boolean guard structure to be preserved",
+        );
+    }
+
+    #[test]
+    fn query_receive_sugar_with_string_guard() {
+        assert_query_desugars(
+            "for(p <- x!?(a) where p == \"ok\"){p}",
+            "new(r) in { { x!(*r, a) | for(p <- r where p == \"ok\"){p} } }",
+            "expected string equality guard to survive desugaring",
+        );
+    }
+
+    #[test]
+    fn query_receive_sugar_with_list_arg() {
+        assert_query_desugars(
+            "for(p <- x!?([1,2,3])){p}",
+            "new(r) in { { x!(*r, [1,2,3]) | for(p <- r){p} } }",
+            "expected list argument to remain unchanged in query send",
+        );
+    }
+
+    #[test]
+    fn query_receive_sugar_with_map_arg() {
+        assert_query_desugars(
+            "for(p <- x!?(map(1:2, 3:4))){p}",
+            "new(r) in { { x!(*r, map(1:2, 3:4)) | for(p <- r){p} } }",
+            "expected map argument to remain unchanged in query send",
+        );
+    }
+
+    #[test]
+    fn query_receive_sugar_with_bag_arg() {
+        assert_query_desugars(
+            "for(p <- x!?(#{1|2}#)){p}",
+            "new(r) in { { x!(*r, #{1|2}#) | for(p <- r){p} } }",
+            "expected bag argument to remain unchanged in query send",
+        );
+    }
+
+    #[test]
+    fn query_receive_sugar_body_uses_bound_name() {
+        assert_query_desugars(
+            "for(p <- x!?(a)){*p}",
+            "new(r) in { { x!(*r, a) | for(p <- r){*p} } }",
+            "expected body to keep bound name usage after desugaring",
+        );
+    }
+
+    #[test]
+    fn query_receive_sugar_body_parallel_structure() {
+        assert_query_desugars(
+            "for(p <- x!?(a)){{*p | ok}}",
+            "new(r) in { { x!(*r, a) | for(p <- r){{*p | ok}} } }",
+            "expected body parallel structure to be preserved",
+        );
+    }
+
+    #[test]
+    fn query_receive_sugar_with_new_in_body() {
+        assert_query_desugars(
+            "for(p <- x!?(a)){new(k) in {k!(0)}}",
+            "new(r) in { { x!(*r, a) | for(p <- r){new(k) in {k!(0)}} } }",
+            "expected nested new in body to be preserved",
+        );
+    }
+
+    #[test]
+    fn query_receive_sugar_rows_with_where_and_plain_followup() {
+        assert_query_desugars(
+            "for(p <- x!?(a) & q <- y!?(b) where p == q; z <- c){z}",
+            "new(r1, r2) in { { x!(*r1, a) | y!(*r2, b) | for(p <- r1 & q <- r2 where p == q; z <- c){z} } }",
+            "expected mixed where+row composition to survive desugaring",
+        );
+    }
+
+    #[test]
+    fn query_receive_sugar_plain_then_query_with_where() {
+        assert_query_desugars(
+            "for(z <- c; p <- x!?(a) where p == ok){z}",
+            "new(r) in { { x!(*r, a) | for(z <- c; p <- r where p == ok){z} } }",
+            "expected where guard in later query row to be preserved",
+        );
+    }
+
+    #[test]
+    fn query_receive_sugar_three_rows_two_queries_one_plain() {
+        assert_query_desugars(
+            "for(p <- x!?(a); q <- c; r <- y!?(b)){q}",
+            "new(r1, r2) in { { x!(*r1, a) | y!(*r2, b) | for(p <- r1; q <- c; r <- r2){q} } }",
+            "expected multi-row ordering with two queries to be preserved",
         );
     }
     #[test]

--- a/languages/tests/rhocalc_tests.rs
+++ b/languages/tests/rhocalc_tests.rs
@@ -224,7 +224,7 @@ mod comm {
     fn join_pattern_mismatch_is_noop_for_receive_group() {
         assert_reduces_to(
             "{for(@[1,2,4] <- c){7} | c!([1,2,3])}",
-            "{__for([1,2,4] <- c){7} | c!([1,2,3])}",
+            "{for(@[1,2,4] <- c){7} | c!([1,2,3])}",
         );
         assert_never_produces("{for(@[1,2,4] <- c){7} | c!([1,2,3])}", "{7}");
     }
@@ -985,8 +985,8 @@ mod parsing {
 
     fn assert_query_desugars(sugar_src: &str, rhs_src: &str, msg: &str) {
         fresh();
-        let sugar = parse(sugar_src);
-        let rhs = parse(rhs_src);
+        let sugar = parse(sugar_src).normalize();
+        let rhs = parse(rhs_src).normalize();
         assert!(sugar.term_eq(&rhs), "{}", msg);
     }
 
@@ -1027,78 +1027,70 @@ mod parsing {
     #[test]
     fn send_polyadic_is_list_sugar() {
         fresh();
-        let poly = parse("x!(1, 2, 3)");
-        let list = parse("x!([1, 2, 3])");
+        let poly = parse("x!(1, 2, 3)").normalize();
+        let list = parse("x!([1, 2, 3])").normalize();
         assert!(poly.term_eq(&list), "expected polyadic send sugar to match list payload");
     }
 
     #[test]
     fn send_polyadic_two_args_is_list_sugar() {
         fresh();
-        let poly = parse("x!(1, 2)");
-        let list = parse("x!([1, 2])");
+        let poly = parse("x!(1, 2)").normalize();
+        let list = parse("x!([1, 2])").normalize();
         assert!(poly.term_eq(&list), "expected 2-arg send sugar to match list payload");
     }
 
     #[test]
     fn query_receive_sugar_single() {
-        fresh();
-        let sugar = parse("for(p <- x!?(a, b)){p}");
-        let rhs = parse("new(r) in { { x!(*r, a, b) | for(p <- r){p} } }");
-        assert!(sugar.term_eq(&rhs), "expected `!?` to desugar to `new` + send + receive");
+        assert_query_desugars(
+            "for(p <- x!?(a, b)){p}",
+            "new(r) in { { x!(*r, a, b) | for(p <- r){p} } }",
+            "expected `!?` to desugar to `new` + send + receive",
+        );
     }
 
     #[test]
     fn query_receive_sugar_zero_args() {
-        fresh();
-        let sugar = parse("for(p <- x!?()){p}");
-        let rhs = parse("new(r) in { { x!(*r) | for(p <- r){p} } }");
-        assert!(sugar.term_eq(&rhs), "expected zero-arg `!?` to pass only return channel");
+        assert_query_desugars(
+            "for(p <- x!?()){p}",
+            "new(r) in { { x!(*r) | for(p <- r){p} } }",
+            "expected zero-arg `!?` to pass only return channel",
+        );
     }
 
     #[test]
     fn query_receive_sugar_single_with_where() {
-        fresh();
-        let sugar = parse("for(p <- x!?(a, b) where p == ok){p}");
-        let rhs = parse("new(r) in { { x!(*r, a, b) | for(p <- r where p == ok){p} } }");
-        assert!(
-            sugar.term_eq(&rhs),
-            "expected `!?` bind with where-guard to desugar through private return channel"
+        assert_query_desugars(
+            "for(p <- x!?(a, b) where p == ok){p}",
+            "new(r) in { { x!(*r, a, b) | for(p <- r where p == ok){p} } }",
+            "expected `!?` bind with where-guard to desugar through private return channel",
         );
     }
 
     #[test]
     fn query_receive_sugar_multiple_joins() {
-        fresh();
-        let sugar = parse("for(p <- x1!?(a1) & q <- x2!?(a2) & z <- c){z}");
-        let rhs = parse(
+        assert_query_desugars(
+            "for(p <- x1!?(a1) & q <- x2!?(a2) & z <- c){z}",
             "new(r1, r2) in { { x1!(*r1, a1) | x2!(*r2, a2) | for(p <- r1 & q <- r2 & z <- c){z} } }",
-        );
-        assert!(
-            sugar.term_eq(&rhs),
-            "expected multiple `!?` binds to desugar to multiple return channels"
+            "expected multiple `!?` binds to desugar to multiple return channels",
         );
     }
 
     #[test]
     fn query_receive_sugar_mixed_join_with_plain_bind() {
-        fresh();
-        let sugar = parse("for(p <- x!?(a) & q <- c){q}");
-        let rhs = parse("new(r) in { { x!(*r, a) | for(p <- r & q <- c){q} } }");
-        assert!(
-            sugar.term_eq(&rhs),
-            "expected `!?` bind to compose with plain join binds"
+        assert_query_desugars(
+            "for(p <- x!?(a) & q <- c){q}",
+            "new(r) in { { x!(*r, a) | for(p <- r & q <- c){q} } }",
+            "expected `!?` bind to compose with plain join binds",
         );
     }
 
     #[test]
     fn query_receive_sugar_mixed_rows_with_plain_bind() {
-        fresh();
-        let sugar = parse("for(p <- x!?(a); q <- c){q}");
-        let rhs = parse("new(r) in { { x!(*r, a) | for(p <- r; q <- c){q} } }");
-        assert!(
-            sugar.term_eq(&rhs),
-            "expected `!?` bind to compose with semicolon-separated rows"
+        assert_query_desugars(
+            "for(p <- x!?(a); q <- c){q}",
+            "new(r) in { { x!(*r, a) | for(p <- r; q <- c){q} } }",
+            "expected `!?` bind to compose with semicolon-separated rows",
         );
     }
 

--- a/macros/src/ast/language.rs
+++ b/macros/src/ast/language.rs
@@ -380,15 +380,6 @@ impl LanguageDef {
             .map(|t| &t.name)
     }
 
-    /// Type name for the Map category (e.g. "Map") if present.
-    #[allow(dead_code)]
-    pub fn map_type_name(&self) -> Option<&Ident> {
-        self.types
-            .iter()
-            .find(|t| matches!(t.collection_kind.as_ref(), Some(CollectionCategory::Map(_))))
-            .map(|t| &t.name)
-    }
-
     /// Label of the term that injects a collection type (List, Bag, Map) into the primary category.
     /// E.g. for RhoCalc with CastList . l:List |- l : Proc, returns CastList for "List".
     pub fn injection_term_label_for_collection(&self, collection_type: &str) -> Option<Ident> {

--- a/prattail/src/automata/codegen.rs
+++ b/prattail/src/automata/codegen.rs
@@ -366,26 +366,6 @@ fn write_transition_arms(buf: &mut String, dfa: &Dfa) {
     buf.push_str("_ => u32::MAX }");
 }
 
-/// Write the flat transition table to a string buffer (for table-driven lexer).
-///
-/// Superseded by `write_comb_tables()` — preserved for reference and testing.
-#[allow(dead_code)]
-fn write_transition_table(buf: &mut String, dfa: &Dfa, num_classes: usize) {
-    let table_size = dfa.states.len() * num_classes;
-    write!(buf, "static TRANSITIONS: [u32; {}] = [", table_size).unwrap();
-    let mut first = true;
-    for state in &dfa.states {
-        for &target in &state.transitions {
-            if !first {
-                buf.push(',');
-            }
-            first = false;
-            write!(buf, "{}", target).unwrap();
-        }
-    }
-    buf.push_str("];");
-}
-
 /// Write a TokenKind constructor expression to a string buffer.
 ///
 /// Zero-copy: string-carrying variants borrow from the input `text` slice
@@ -718,100 +698,6 @@ fn write_lex_weighted_function_direct_coded(buf: &mut String) {
          tokens.push((Token::Eof, Range { start: eof_pos, end: eof_pos, file_id }, 0.0_f64)); \
          Ok(tokens) }",
     );
-}
-
-/// Write a complete table-driven lexer to a string buffer (flat transition table).
-///
-/// Superseded by `write_comb_driven_lexer()` and `write_bitmap_driven_lexer()`
-/// — preserved for reference and testing.
-#[allow(dead_code)]
-fn write_table_driven_lexer(buf: &mut String, dfa: &Dfa, partition: &AlphabetPartition) {
-    let num_classes = partition.num_classes;
-
-    write_class_table(buf, partition);
-    write_transition_table(buf, dfa, num_classes);
-    write_lex_accept_priority_table(buf, dfa);
-
-    write!(
-        buf,
-        "const NUM_STATES: usize = {}; const NUM_CLASSES: usize = {}; const DEAD: u32 = u32::MAX;",
-        dfa.states.len(),
-        num_classes
-    )
-    .unwrap();
-
-    buf.push_str(
-        "fn is_whitespace(b: u8) -> bool { matches!(b, b' ' | b'\\t' | b'\\n' | b'\\r') }",
-    );
-
-    // lex() function with line/column tracking — zero-copy: Token<'a> borrows from input
-    buf.push_str(
-        "pub fn lex<'a>(input: &'a str) -> Result<Vec<(Token<'a>, Range)>, String> { \
-         lex_with_file_id(input, None) \
-         }\n\
-         pub fn lex_with_file_id<'a>(input: &'a str, file_id: Option<u32>) -> Result<Vec<(Token<'a>, Range)>, String> { \
-         let bytes = input.as_bytes(); \
-         let mut pos: usize = 0; \
-         let mut line: usize = 0; \
-         let mut col: usize = 0; \
-         let mut tokens: Vec<(Token<'a>, Range)> = Vec::with_capacity(input.len() / 2); \
-         while pos < bytes.len() { \
-         while pos < bytes.len() && is_whitespace(bytes[pos]) { \
-         if bytes[pos] == b'\\n' { line += 1; col = 0; } else { col += 1; } \
-         pos += 1; } \
-         if pos >= bytes.len() { break; } \
-         let start = pos; \
-         let start_line = line; \
-         let start_col = col; \
-         let mut state: u32 = 0; \
-         let mut last_accept: Option<(u32, usize, usize, usize, f64)> = None; \
-         if accept_token(0, &input[start..start]).is_some() { \
-         let w0 = LEX_ACCEPT_PRIORITY[0]; \
-         last_accept = Some((0, pos, line, col, w0)); \
-         } \
-         while pos < bytes.len() { \
-         let class = CHAR_CLASS[bytes[pos] as usize] as usize; \
-         let next = TRANSITIONS[state as usize * NUM_CLASSES + class]; \
-         if next == DEAD { break; } \
-         state = next; \
-         if bytes[pos] == b'\\n' { line += 1; col = 0; } \
-         else if bytes[pos] & 0xC0 != 0x80 { col += 1; } \
-         pos += 1; \
-         if accept_token(state, &input[start..pos]).is_some() { \
-         let w = LEX_ACCEPT_PRIORITY[state as usize]; \
-         let replace = match last_accept { \
-         None => true, \
-         Some((_, old_end, _, _, old_w)) => pos > old_end || (pos == old_end && w < old_w), \
-         }; \
-         if replace { last_accept = Some((state, pos, line, col, w)); } \
-         } \
-         } \
-         match last_accept { \
-         Some((accept_state, end, end_line, end_col, _)) => { \
-         pos = end; line = end_line; col = end_col; \
-         let text = &input[start..end]; \
-         if let Some(token) = accept_token(accept_state, text) { \
-         tokens.push((token, Range { \
-         start: Position { byte_offset: start, line: start_line, column: start_col }, \
-         end: Position { byte_offset: end, line: end_line, column: end_col }, \
-         file_id })); } } \
-         None => { return Err(format!(\"{}:{}: unexpected character '{}'\", \
-         line + 1, col + 1, bytes[start] as char)); } \
-         } } \
-         let eof_pos = Position { byte_offset: pos, line, column: col }; \
-         tokens.push((Token::Eof, Range { start: eof_pos, end: eof_pos, file_id })); \
-         Ok(tokens) }",
-    );
-
-    // accept_token() function — returns Token<'a> borrowing from text
-    buf.push_str("fn accept_token<'a>(state: u32, text: &'a str) -> Option<Token<'a>> {");
-    write_accept_arms(
-        buf,
-        dfa,
-        &std::collections::HashMap::new(),
-        &std::collections::HashMap::new(),
-    );
-    buf.push('}');
 }
 
 // ══════════════════════════════════════════════════════════════════════════════

--- a/prattail/src/dispatch.rs
+++ b/prattail/src/dispatch.rs
@@ -134,7 +134,18 @@ pub fn write_category_dispatch(
                                 }} \
                                 match nfa_results.len() {{ \
                                     0 => Err(nfa_first_err.expect(\"at least one parse attempted\")), \
-                                    _ => {{ *pos = nfa_positions[0]; Ok(nfa_results.into_iter().next().expect(\"nfa_results non-empty\")) }}, \
+                                    _ => {{ \
+                                        let mut best_idx = 0usize; \
+                                        for i in 1..nfa_positions.len() {{ \
+                                            if nfa_positions[i] > nfa_positions[best_idx] {{ \
+                                                best_idx = i; \
+                                            }} \
+                                        }} \
+                                        *pos = nfa_positions[best_idx]; \
+                                        let mut it = nfa_results.into_iter(); \
+                                        let chosen = it.nth(best_idx).expect(\"best_idx in bounds\"); \
+                                        Ok(chosen) \
+                                    }}, \
                                 }} \
                             }}",
                             category = category,
@@ -431,7 +442,18 @@ pub fn write_category_dispatch_weighted(
                     }} \
                     match nfa_results.len() {{ \
                         0 => Err(nfa_first_err.expect(\"at least one parse attempted\")), \
-                        _ => {{ *pos = nfa_positions[0]; Ok(nfa_results.into_iter().next().expect(\"nfa_results non-empty\")) }}, \
+                        _ => {{ \
+                            let mut best_idx = 0usize; \
+                            for i in 1..nfa_positions.len() {{ \
+                                if nfa_positions[i] > nfa_positions[best_idx] {{ \
+                                    best_idx = i; \
+                                }} \
+                            }} \
+                            *pos = nfa_positions[best_idx]; \
+                            let mut it = nfa_results.into_iter(); \
+                            let chosen = it.nth(best_idx).expect(\"best_idx in bounds\"); \
+                            Ok(chosen) \
+                        }}, \
                     }} \
                 }}",
                 category = category,

--- a/prattail/src/pratt.rs
+++ b/prattail/src/pratt.rs
@@ -505,7 +505,20 @@ fn write_prefix_handler(buf: &mut String, config: &PrattConfig, prefix_handlers:
                     )),",
                 )
                 .unwrap();
-                arm.push_str("_ => { *pos = nfa_positions[0]; Ok(nfa_results.into_iter().next().expect(\"nfa_results non-empty\")) },");
+                arm.push_str(
+                    "_ => { \
+                        let mut best_idx = 0usize; \
+                        for i in 1..nfa_positions.len() { \
+                            if nfa_positions[i] > nfa_positions[best_idx] { \
+                                best_idx = i; \
+                            } \
+                        } \
+                        *pos = nfa_positions[best_idx]; \
+                        let mut it = nfa_results.into_iter(); \
+                        let chosen = it.nth(best_idx).expect(\"best_idx in bounds\"); \
+                        Ok(chosen) \
+                    },",
+                );
                 arm.push('}'); // close match
                 arm.push('}'); // close arm body
                 match_arms.push(arm);
@@ -695,11 +708,69 @@ fn write_prefix_handler(buf: &mut String, config: &PrattConfig, prefix_handlers:
     // so we dereference with `*name` to get `&str` and `.to_string()` for ownership.
     if !lookahead_handlers.is_empty() {
         let mut arm = String::from("Token::Ident(name) => { match peek_ahead(tokens, *pos, 1) {");
+        let mut by_variant: std::collections::BTreeMap<String, Vec<&PrefixHandler>> =
+            std::collections::BTreeMap::new();
         for handler in &lookahead_handlers {
             let terminal = handler.ident_lookahead.as_ref().expect("checked above");
             let variant = crate::automata::codegen::terminal_to_variant_name(terminal);
-            write!(arm, "Some(Token::{}) => {}(tokens, pos),", variant, handler.parse_fn_name)
+            by_variant.entry(variant).or_default().push(handler);
+        }
+        for (variant, handlers) in by_variant {
+            if handlers.len() == 1 {
+                write!(
+                    arm,
+                    "Some(Token::{}) => {}(tokens, pos),",
+                    variant, handlers[0].parse_fn_name
+                )
                 .unwrap();
+            } else {
+                write!(
+                    arm,
+                    "Some(Token::{}) => {{ \
+                        let nfa_saved = *pos; \
+                        let mut nfa_results: Vec<{cat}> = Vec::new(); \
+                        let mut nfa_positions: Vec<usize> = Vec::new(); \
+                        let mut nfa_first_err: Option<ParseError> = None;",
+                    variant
+                )
+                .unwrap();
+                for handler in handlers {
+                    write!(
+                        arm,
+                        "*pos = nfa_saved; \
+                         match {}(tokens, pos) {{ \
+                             Ok(v) => {{ nfa_results.push(v); nfa_positions.push(*pos); }}, \
+                             Err(e) => {{ if nfa_first_err.is_none() {{ nfa_first_err = Some(e); }} }}, \
+                         }}",
+                        handler.parse_fn_name
+                    )
+                    .unwrap();
+                }
+                arm.push_str(
+                    "match nfa_results.len() { \
+                        0 => Err(nfa_first_err.unwrap_or_else(|| \
+                            ParseError::UnexpectedToken { \
+                                expected: \"expression after identifier\", \
+                                found: tokens.get(nfa_saved + 1).map(|(t, _)| format!(\"{:?}\", t)).unwrap_or_else(|| \"<eof>\".to_string()), \
+                                range: tokens.get(nfa_saved).map(|(_, r)| *r).unwrap_or(Range::zero()), \
+                            } \
+                        )), \
+                        _ => { \
+                            let mut best_idx = 0usize; \
+                            for i in 1..nfa_positions.len() { \
+                                if nfa_positions[i] > nfa_positions[best_idx] { \
+                                    best_idx = i; \
+                                } \
+                            } \
+                            *pos = nfa_positions[best_idx]; \
+                            let mut it = nfa_results.into_iter(); \
+                            let chosen = it.nth(best_idx).expect(\"best_idx in bounds\"); \
+                            Ok(chosen) \
+                        }, \
+                    } \
+                },",
+                );
+            }
         }
         // Default: variable fallback
         write!(

--- a/prattail/src/prediction.rs
+++ b/prattail/src/prediction.rs
@@ -954,7 +954,7 @@ pub fn detect_grammar_warnings(
     let mut warnings = Vec::new();
 
     // 1. Ambiguous prefix dispatch
-    detect_ambiguous_prefix(rules, categories, &mut warnings);
+    detect_ambiguous_prefix(rules, categories, all_syntax, &mut warnings);
 
     // 2. Left-recursion
     detect_left_recursion(all_syntax, &mut warnings);
@@ -970,9 +970,28 @@ pub fn detect_grammar_warnings(
 fn detect_ambiguous_prefix(
     rules: &[RuleInfo],
     categories: &[String],
+    all_syntax: &[(String, String, Vec<crate::SyntaxItemSpec>)],
     warnings: &mut Vec<GrammarWarning>,
 ) {
     use std::collections::BTreeMap;
+
+    // (category, label) -> terminal skeleton
+    let terminal_skeletons: BTreeMap<(String, String), Vec<String>> = all_syntax
+        .iter()
+        .map(|(label, category, syntax)| {
+            let terminals = syntax
+                .iter()
+                .filter_map(|item| {
+                    if let crate::SyntaxItemSpec::Terminal(t) = item {
+                        Some(t.clone())
+                    } else {
+                        None
+                    }
+                })
+                .collect::<Vec<_>>();
+            ((category.clone(), label.clone()), terminals)
+        })
+        .collect();
 
     for cat in categories {
         // Collect non-infix, non-var, non-literal rules for this category
@@ -998,6 +1017,24 @@ fn detect_ambiguous_prefix(
         // Report ambiguities (2+ rules for the same terminal)
         for (token, rule_labels) in &terminal_to_rules {
             if rule_labels.len() > 1 {
+                // If all matching rules have distinct terminal skeletons, dispatch can
+                // usually be resolved by deeper lookahead after shared prefix tokens.
+                // Keep the warning only when at least two rules are terminal-equivalent
+                // (or syntax metadata is unavailable).
+                let mut sig_count: BTreeMap<Vec<String>, usize> = BTreeMap::new();
+                let mut missing_sig = false;
+                for label in rule_labels {
+                    if let Some(sig) = terminal_skeletons.get(&(cat.clone(), label.clone())) {
+                        *sig_count.entry(sig.clone()).or_default() += 1;
+                    } else {
+                        missing_sig = true;
+                    }
+                }
+                let has_equivalent_signatures = sig_count.values().any(|count| *count > 1);
+                if !missing_sig && !has_equivalent_signatures {
+                    continue;
+                }
+
                 warnings.push(GrammarWarning::AmbiguousPrefix {
                     token: token.clone(),
                     category: cat.clone(),

--- a/prattail/src/tests/warning_tests.rs
+++ b/prattail/src/tests/warning_tests.rs
@@ -93,6 +93,59 @@ fn test_no_ambiguity_for_infix_rules() {
 }
 
 #[test]
+fn test_no_ambiguity_when_terminal_skeletons_differ() {
+    // Same first token in category, but one rule has an additional terminal tail.
+    // This mirrors rhocalc InputBindQuoted vs InputBindQuotedQuery.
+    let rules = vec![
+        make_rule_info(
+            "InputBindQuoted",
+            "InputBind",
+            vec![FirstItem::Terminal("@".to_string())],
+            false,
+        ),
+        make_rule_info(
+            "InputBindQuotedQuery",
+            "InputBind",
+            vec![FirstItem::Terminal("@".to_string())],
+            false,
+        ),
+    ];
+    let categories = vec!["InputBind".to_string()];
+    let syntax = vec![
+        (
+            "InputBindQuoted".to_string(),
+            "InputBind".to_string(),
+            vec![
+                SyntaxItemSpec::Terminal("@".to_string()),
+                SyntaxItemSpec::Terminal("<-".to_string()),
+            ],
+        ),
+        (
+            "InputBindQuotedQuery".to_string(),
+            "InputBind".to_string(),
+            vec![
+                SyntaxItemSpec::Terminal("@".to_string()),
+                SyntaxItemSpec::Terminal("<-".to_string()),
+                SyntaxItemSpec::Terminal("!".to_string()),
+                SyntaxItemSpec::Terminal("?".to_string()),
+                SyntaxItemSpec::Terminal("(".to_string()),
+                SyntaxItemSpec::Terminal(")".to_string()),
+            ],
+        ),
+    ];
+
+    let warnings = detect_grammar_warnings(&rules, &categories, &syntax);
+
+    assert!(
+        !warnings
+            .iter()
+            .any(|w| matches!(w, GrammarWarning::AmbiguousPrefix { .. })),
+        "rules with distinct terminal skeletons should not be reported ambiguous: {:?}",
+        warnings
+    );
+}
+
+#[test]
 fn test_no_ambiguity_for_var_rules() {
     // Var rules should be excluded from ambiguity check
     let rules = vec![

--- a/prattail/src/trampoline.rs
+++ b/prattail/src/trampoline.rs
@@ -1299,26 +1299,67 @@ fn write_prefix_match_arms(
             })
             .collect();
 
-        let mut seen: std::collections::HashSet<String> = ident_lookahead_cases
-            .iter()
-            .map(|(t, _)| t.clone())
-            .collect();
-        for (term, fn_name) in rd_fallback {
-            if seen.insert(term.clone()) {
-                ident_lookahead_cases.push((term, fn_name));
-            }
-        }
+        // Keep all candidates, including multiple parse fns for the same lookahead terminal.
+        // Ambiguous lookahead terminals are disambiguated below via backtracking + longest match.
+        ident_lookahead_cases.extend(rd_fallback);
 
         if !ident_lookahead_cases.is_empty() {
             let mut arm =
                 String::from("Token::Ident(name) => { match peek_ahead(tokens, *pos, 1) {");
+            let mut grouped_cases: std::collections::BTreeMap<String, Vec<String>> =
+                std::collections::BTreeMap::new();
             for (terminal, parse_fn_name) in &ident_lookahead_cases {
+                grouped_cases
+                    .entry(terminal.clone())
+                    .or_default()
+                    .push(parse_fn_name.clone());
+            }
+            for (terminal, parse_fns) in &grouped_cases {
                 let variant = terminal_to_variant_name(terminal);
-                write!(arm, "Some(Token::{}) => {{ match {}(tokens, pos) {{ Ok(v) => break 'prefix v, Err(e) => {{ match stack.pop() {{ None => return Err(e),",
-                    variant, parse_fn_name).unwrap();
-                // Collection catch on error
-                write_collection_error_catch_inline(&mut arm, config, rd_rules, frame_info);
-                arm.push_str("Some(_) => return Err(e), } } } },");
+                if parse_fns.len() == 1 {
+                    write!(arm, "Some(Token::{}) => {{ match {}(tokens, pos) {{ Ok(v) => break 'prefix v, Err(e) => {{ match stack.pop() {{ None => return Err(e),",
+                        variant, parse_fns[0]).unwrap();
+                    // Collection catch on error
+                    write_collection_error_catch_inline(&mut arm, config, rd_rules, frame_info);
+                    arm.push_str("Some(_) => return Err(e), } } } },");
+                } else {
+                    write!(
+                        arm,
+                        "Some(Token::{}) => {{ \
+                            let __saved = *pos; \
+                            let mut __best_pos = __saved; \
+                            let mut __best_val: Option<{cat}> = None; \
+                            let mut __first_err: Option<ParseError> = None;",
+                        variant
+                    )
+                    .unwrap();
+                    for parse_fn_name in parse_fns {
+                        write!(
+                            arm,
+                            "*pos = __saved; \
+                             match {}(tokens, pos) {{ \
+                                 Ok(v) => {{ if __best_val.is_none() || *pos > __best_pos {{ __best_pos = *pos; __best_val = Some(v); }} }}, \
+                                 Err(e) => {{ if __first_err.is_none() {{ __first_err = Some(e); }} }}, \
+                             }}",
+                            parse_fn_name
+                        )
+                        .unwrap();
+                    }
+                    arm.push_str(
+                        "if let Some(v) = __best_val { \
+                            *pos = __best_pos; \
+                            break 'prefix v; \
+                        } \
+                        let e = __first_err.unwrap_or(ParseError::UnexpectedToken { \
+                            expected: \"identifier lookahead parse\", \
+                            found: format!(\"{:?}\", tokens.get(__saved + 1).map(|(t, _)| t).unwrap_or(&Token::Eof)), \
+                            range: tokens.get(__saved).map(|(_, r)| *r).unwrap_or(Range::zero()), \
+                        }); \
+                        match stack.pop() { None => return Err(e),",
+                    );
+                    write_collection_error_catch_inline(&mut arm, config, rd_rules, frame_info);
+                    arm.push_str("Some(_) => return Err(e), } },");
+                }
             }
             // Default: variable fallback
             write!(

--- a/repl/src/repl.rs
+++ b/repl/src/repl.rs
@@ -1003,7 +1003,7 @@ impl Repl {
                 } else {
                     print!("Parsing... ");
                     let t = language
-                        .parse_term_for_env(term_str)
+                        .parse_term(term_str)
                         .map_err(|e| anyhow::anyhow!("{}", e))?;
                     println!("{}", "✓".green());
                     (t, false)
@@ -1011,7 +1011,7 @@ impl Repl {
             } else {
                 print!("Parsing... ");
                 let t = language
-                    .parse_term_for_env(term_str)
+                    .parse_term(term_str)
                     .map_err(|e| anyhow::anyhow!("{}", e))?;
                 println!("{}", "✓".green());
                 (t, false)
@@ -1019,7 +1019,7 @@ impl Repl {
         } else {
             print!("Parsing... ");
             let t = language
-                .parse_term_for_env(term_str)
+                .parse_term(term_str)
                 .map_err(|e| anyhow::anyhow!("{}", e))?;
             println!("{}", "✓".green());
             (t, false)


### PR DESCRIPTION
This PR implements the !? syntax. The syntax defines a request-response pattern that uses a private return channel and specific arguments to actively query a contract for data. It is implementable purely as sugar, includes just term constructors plus equations.  Because it's literally equal to the RHS that doesn't use !?, it should rewrite in the expected way.

Examples (the syntax and the following Rholang native equivalent code):
for( ptrn <- x!?( a1, ..., ak ) & <joins> where <cond> ) {
  P
} = 
new r in {
  x!( *r, a1, ..., ak ) | 
  for( ptrn <- r & <joins> where <cond> ) {
    ⟦P⟧
  } 
}

Multiple !? clauses work like this:
for( ptrn1 <- x1!?( a1, ..., ak ) & ptrn2 <- x2!?( a1, ..., ak ) & <joins> where <cond> ){
  P
} = 
new r1, r2 in {
  x1!( *r1, a1, ..., ak ) | 
  x2!( *r2, a1, ..., ak ) | 
  for( ptrn1 <- r1 & ptrn2 <- r2 & <joins> where <cond> ) {
    P
  } 
}
etc.

The right-hand side follows from the left because joins are unordered:
  for (ptrn1 <- x1 & ptrn2 <- x2 & ptrn3 <- x3) { P }
 = for (ptrn1 <- x1 & ptrn3 <- x3 & ptrn2 <- x2) { P }
 = for (ptrn2 <- x2 & ptrn1 <- x1 & ptrn3 <- x3) { P }
 = for (ptrn2 <- x2 & ptrn3 <- x3 & ptrn1 <- x1) { P }
 = for (ptrn3 <- x3 & ptrn1 <- x1 & ptrn2 <- x2) { P }
 = for (ptrn3 <- x3 & ptrn2 <- x2 & ptrn1 <- x1) { P }
