### PR TITLE
Rhocalc collection wire

### DIFF
--- a/docs/design/exploring/rhocalc-rholang-style-syntax.md
+++ b/docs/design/exploring/rhocalc-rholang-style-syntax.md
@@ -10,6 +10,7 @@ Cross-links:
 - [docs/examples/rhocalc/01-language-spec.md](../../examples/rhocalc/01-language-spec.md) — surface-syntax reference
 - [docs/manual/language/features/collections/00-overview.md](../../manual/language/features/collections/00-overview.md) — collection overview
 - [docs/design/made/rhocalc-collection-equality.md](../made/rhocalc-collection-equality.md) — `==` / `!=` on collection casts at fold and in `where` guards
+- [docs/design/made/rhocalc-collection-wire.md](../made/rhocalc-collection-wire.md) — `.toByteArray()` protobuf wire encoding for collection casts
 
 ---
 

--- a/docs/design/made/native-types/set-type-design.md
+++ b/docs/design/made/native-types/set-type-design.md
@@ -11,7 +11,7 @@
 
 **Scope:** `![mettail_runtime::HashSetLit<Proc>] as Set` in `language! { types { … } }`. Default literal delimiters are `Set(`, `)`, `,` (`CollectionCategory::set_defaults()`). `Set()` is an explicit empty-set alias. Rhocalc **Bag** (`#{…}#`) remains the multiset / parallel-composition surface with no Rholang counterpart.
 
-**Non-goals:** `toByteArray`, partial collection patterns, changing Bag syntax to Rholang `Set`.
+**Non-goals:** partial collection patterns, changing Bag syntax to Rholang `Set`. Surface `.toByteArray()` is specified in [rhocalc-collection-wire.md](./rhocalc-collection-wire.md).
 
 ---
 

--- a/docs/design/made/rhocalc-collection-wire.md
+++ b/docs/design/made/rhocalc-collection-wire.md
@@ -1,0 +1,68 @@
+# Rhocalc Collection Wire / `toByteArray()`
+
+**Status:** Implemented (RhoCalc)  
+**Context:** Surface `toByteArray()` on `CastList`, `CastBag`, `CastMap`, and `CastSet`; see [rhocalc-collection-equality.md](./rhocalc-collection-equality.md), [map-type-design.md](./native-types/map-type-design.md), [set-type-design.md](./native-types/set-type-design.md), and [lists-and-bags-support.md](./native-types/lists-and-bags-support.md).
+
+**References:** [Rholang data structures](https://rholang.org/tutorials/data-structures/), [f1r3node `03-data-types`](https://github.com/F1R3FLY-io/f1r3node/blob/rust/dev/docs/rholang/03-data-types.md), [f1r3node `06-collections`](https://github.com/F1R3FLY-io/f1r3node/blob/rust/dev/docs/rholang/06-collections.md).
+
+---
+
+## 1. Goal and Scope
+
+**Goal:** Fold-time `.toByteArray()` on Rhocalc collection values injected into `Proc`, returning a `CastBytes` payload whose bytes match f1r3node `Par` protobuf encoding for the corresponding Rholang collection kind.
+
+**Scope:** `MToByteArray` in [`languages/src/rhocalc.rs`](../../languages/src/rhocalc.rs), encoder in [`languages/src/rhocalc/wire.rs`](../../languages/src/rhocalc/wire.rs), and `collection_wire` tests in [`languages/tests/rhocalc_tests.rs`](../../languages/tests/rhocalc_tests.rs).
+
+**Non-goals:** tuples; PathMap / Zipper; full rho-calculus `Par` wire; decode / `fromByteArray`; string `hexToBytes` / `toUtf8Bytes`; byte-array `slice` / `nth` / `length`; Calculator; equality on braced `PPar` multisets (not `CastBag`).
+
+---
+
+## 2. Surface Contract
+
+| Kind | Example | `toByteArray()` |
+|------|---------|-----------------|
+| List | `[1, 2, 3]` | zero-arg method; protobuf `EList { ps }` |
+| Set | `Set(1, 2, 3)` | zero-arg method; protobuf `ESet { ps }` with sorted `Par` keys |
+| Map | `{1: 10, 2: 20}` | zero-arg method; protobuf `EMap { kvs }` with sorted keys |
+| Bag | `#{1 \| 2 \| 2}#` | Rhocalc extension: multiset expanded to `EList` after `normalize_bag_elements` |
+
+Results are injected as `CastBytes` with a `Bytes::StringLit` **lowercase hex** display (no Rholang byte literal syntax in v1).
+
+---
+
+## 3. Encoder Pipeline
+
+1. Fold receiver to a ground collection cast (`CastList` / `CastBag` / `CastMap` / `CastSet` with literal payloads).
+2. Map ground `Proc` leaves to minimal `rhoapi::Par` / `ExprInstance` messages (subset of `RhoTypes.proto` generated in `languages/build.rs`).
+3. `Par::encode_to_vec()` (prost) produces wire bytes.
+4. Hex-encode bytes into `Bytes::StringLit` and wrap with `CastBytes`.
+
+Set/map entries are sorted by encoded `Par` bytes before serialization. Bag multiplicity is preserved by repeating element `Par` values in an `EList`.
+
+---
+
+## 4. Golden Vectors
+
+Golden bytes are pinned against **f1r3fly-models 0.1.0** / f1r3node `rust/dev` for scalar list/set/map cases (`list_123`, `set_123`, `map_12`). Additional Rhocalc-only vectors cover nested lists and bag multiset expansion in `rhocalc::wire` unit tests and `collection_wire` integration tests.
+
+Enable `rholang-wire` on `mettail-languages` only when running golden-byte integration checks that depend on the reference crate (default tests use the in-tree encoder).
+
+---
+
+## 5. Tests
+
+- `languages/src/rhocalc/wire.rs` — direct encoder golden-byte unit tests.
+- `languages/tests/rhocalc_tests.rs` — `native_ops::collection_wire` fold tests, order-independence for set/map, nested list, bag expansion, unsupported receiver errors.
+
+---
+
+## 6. Examples
+
+```rhocalc
+[1, 2, 3].toByteArray()
+Set(3, 2, 1).toByteArray()
+{2: 20, 1: 10}.toByteArray()
+#{1 | 2 | 2}#.toByteArray()
+```
+
+Each folds to a quoted hex string representing the protobuf-encoded ground `Par` for that collection.

--- a/docs/examples/rhocalc/01-language-spec.md
+++ b/docs/examples/rhocalc/01-language-spec.md
@@ -251,6 +251,14 @@ casts. `where` guards use the same helper via `eval_guard_bool` in
 comparison. See
 [rhocalc-collection-equality.md](../../design/made/rhocalc-collection-equality.md).
 
+### 3.5.2 Collection wire (`toByteArray()`)
+
+Collection casts support zero-argument `.toByteArray()`, which folds to
+`CastBytes` with a lowercase hex encoding of the f1r3node `Par` protobuf bytes
+for the corresponding Rholang collection kind. Bag literals use the Rhocalc
+extension rule (multiset expanded to `EList`). See
+[rhocalc-collection-wire.md](../../design/made/rhocalc-collection-wire.md).
+
 ### 3.6 Unary Prefix with Fold
 
 ```rust

--- a/docs/manual/language/features/collections/00-overview.md
+++ b/docs/manual/language/features/collections/00-overview.md
@@ -97,6 +97,7 @@ for the Rholang-style alignment that drove this split.
 | [02-hashset-and-vec.md](02-hashset-and-vec.md)           | Differences for `HashSet` and `Vec`                  |
 | [03-ascent-decomposition.md](03-ascent-decomposition.md) | Ascent fixpoint rules for collection terms           |
 | [Rhocalc collection equality](../../../../design/made/rhocalc-collection-equality.md) | Surface `==` / `!=` on Rhocalc `CastList` / `CastBag` / `CastMap` / `CastSet` (fold and guards), separate from Ascent `eq_*` |
+| [Rhocalc collection wire](../../../../design/made/rhocalc-collection-wire.md) | Surface `.toByteArray()` on collection casts; protobuf `Par` bytes via `languages/src/rhocalc/wire.rs` |
 
 ## Rhocalc surface equality
 
@@ -105,6 +106,8 @@ Rhocalc programs compare collection values at the `Proc` layer with `==` and
 distinct from Ascent `eq_list`, `eq_bag`, `eq_map`, and `eq_set`, which
 support rewriting and congruence. See
 [rhocalc-collection-equality.md](../../../../design/made/rhocalc-collection-equality.md).
+Collection `.toByteArray()` wire encoding is documented in
+[rhocalc-collection-wire.md](../../../../design/made/rhocalc-collection-wire.md).
 
 ## Source Files
 

--- a/languages/Cargo.toml
+++ b/languages/Cargo.toml
@@ -16,6 +16,8 @@ publish = false
 ## Propagate WFST features through macros to mettail-prattail.
 wfst = ["mettail-macros/wfst"]
 wfst-log = ["mettail-macros/wfst-log"]
+## Golden-byte wire tests against f1r3node reference vectors.
+rholang-wire = []
 
 [dependencies]
 mettail-macros = { path = "../macros" }
@@ -27,13 +29,20 @@ num-traits = "0.2"
 moniker = { workspace = true }
 rand = { workspace = true }
 indexmap = { workspace = true }
+prost = "0.13"
+hex = "0.4"
 
 ascent = { workspace = true }
 ascent-byods-rels = { workspace = true }
 
+[build-dependencies]
+prost-build = "0.13"
+protoc-bin-vendored = "3.2"
+
 [dev-dependencies]
 criterion = { version = "0.5", features = ["html_reports"] }
 proptest = "1"
+hex = "0.4"
 
 [[bench]]
 name = "rhocalc_bench"

--- a/languages/build.rs
+++ b/languages/build.rs
@@ -1,0 +1,6 @@
+fn main() {
+    std::env::set_var("PROTOC", protoc_bin_vendored::protoc_bin_path().expect("vendored protoc"));
+    prost_build::Config::new()
+        .compile_protos(&["proto/rhocalc_wire.proto"], &["proto/"])
+        .expect("compile rhocalc_wire.proto");
+}

--- a/languages/proto/rhocalc_wire.proto
+++ b/languages/proto/rhocalc_wire.proto
@@ -1,0 +1,36 @@
+syntax = "proto3";
+
+package rhoapi;
+
+message Par {
+  repeated Expr exprs = 5;
+}
+
+message Expr {
+  oneof expr_instance {
+    bool g_bool = 1;
+    sint64 g_int = 2;
+    string g_string = 3;
+    bytes g_byte_array = 25;
+    EList e_list_body = 20;
+    ESet e_set_body = 22;
+    EMap e_map_body = 23;
+  }
+}
+
+message EList {
+  repeated Par ps = 1;
+}
+
+message ESet {
+  repeated Par ps = 1;
+}
+
+message EMap {
+  repeated KeyValuePair kvs = 1;
+}
+
+message KeyValuePair {
+  Par key = 1;
+  Par value = 2;
+}

--- a/languages/src/rhocalc.rs
+++ b/languages/src/rhocalc.rs
@@ -11,6 +11,7 @@ use std::ops::Neg;
 pub(crate) mod receive;
 pub(crate) mod runtime;
 mod type_inference;
+pub(crate) mod wire;
 
 language! {
     name: RhoCalc,
@@ -28,6 +29,7 @@ language! {
         ![f64] as Float
         ![bool] as Bool
         ![str] as Str
+        ![String] as Bytes
         ![Vec<Proc>] as List ["[", "]", ","]
         ![mettail_runtime::HashBag<Proc>] as Bag [ "#{", "}#", "|" ]
         ![HashMap<Proc, Proc>] as Map [ "{", "}", ",", ":" ]
@@ -386,6 +388,7 @@ language! {
         CastInt . k:Int |- k : Proc;
         CastBool . k:Bool |- k : Proc;
         CastStr . s:Str |- s : Proc;
+        CastBytes . b:Bytes |- b : Proc;
         CastList . l:List |- l : Proc;
         CastBag . b:Bag |- b : Proc;
         CastMap . m:Map |- m : Proc;
@@ -1235,6 +1238,17 @@ language! {
                         Proc::CastInt(Box::new(Int::NumLit(entries.len() as i64)))
                     },
                     _ => Proc::Err,
+                },
+                _ => Proc::Err,
+            }
+        }] fold;
+
+        MToByteArray . m:Proc
+        |- m "." "toByteArray" "(" ")" : Proc ![{
+            match &m {
+                Proc::CastList(_) | Proc::CastMap(_) | Proc::CastSet(_) | Proc::CastBag(_) => {
+                    crate::rhocalc::wire::collection_to_byte_array_proc(m)
+                        .unwrap_or(Proc::Err)
                 },
                 _ => Proc::Err,
             }

--- a/languages/src/rhocalc/wire.rs
+++ b/languages/src/rhocalc/wire.rs
@@ -1,0 +1,210 @@
+use super::{Bag, Bool, Int, List, Map, Proc, Set, Str};
+use crate::rhocalc::runtime::normalize_bag_elements;
+use mettail_runtime::{HashBag, HashMapLit, HashSetLit};
+use prost::Message;
+
+pub(crate) mod rho_proto {
+    include!(concat!(env!("OUT_DIR"), "/rhoapi.rs"));
+}
+
+use rho_proto::expr::ExprInstance;
+use rho_proto::{EList, EMap, ESet, Expr, KeyValuePair, Par};
+
+#[derive(Debug)]
+pub(crate) enum WireError {
+    UnsupportedProc,
+    NonLiteralCollection,
+}
+
+fn sort_pars(pars: &mut [Par]) {
+    pars.sort_by_key(|left| left.encode_to_vec());
+}
+
+fn sort_map_entries(entries: &mut [(Par, Par)]) {
+    entries.sort_by_key(|(key, _)| key.encode_to_vec());
+}
+
+fn proc_to_par(proc: &Proc) -> Result<Par, WireError> {
+    match proc {
+        Proc::CastInt(inner) => match inner.as_ref() {
+            Int::NumLit(value) => Ok(Par {
+                exprs: vec![Expr {
+                    expr_instance: Some(ExprInstance::GInt(*value)),
+                }],
+            }),
+            _ => Err(WireError::UnsupportedProc),
+        },
+        Proc::CastBool(inner) => match inner.as_ref() {
+            Bool::BoolLit(value) => Ok(Par {
+                exprs: vec![Expr {
+                    expr_instance: Some(ExprInstance::GBool(*value)),
+                }],
+            }),
+            _ => Err(WireError::UnsupportedProc),
+        },
+        Proc::CastStr(inner) => match inner.as_ref() {
+            Str::StringLit(value) => Ok(Par {
+                exprs: vec![Expr {
+                    expr_instance: Some(ExprInstance::GString(value.clone())),
+                }],
+            }),
+            _ => Err(WireError::UnsupportedProc),
+        },
+        Proc::CastList(list) => match list.as_ref() {
+            List::ListLit(elements) => {
+                let ps = elements
+                    .iter()
+                    .map(proc_to_par)
+                    .collect::<Result<Vec<_>, _>>()?;
+                Ok(Par {
+                    exprs: vec![Expr {
+                        expr_instance: Some(ExprInstance::EListBody(EList { ps })),
+                    }],
+                })
+            },
+            _ => Err(WireError::NonLiteralCollection),
+        },
+        Proc::CastSet(set) => match set.as_ref() {
+            Set::SetLit(elements) => {
+                let mut ps = elements
+                    .iter()
+                    .map(proc_to_par)
+                    .collect::<Result<Vec<_>, _>>()?;
+                sort_pars(&mut ps);
+                Ok(Par {
+                    exprs: vec![Expr {
+                        expr_instance: Some(ExprInstance::ESetBody(ESet { ps })),
+                    }],
+                })
+            },
+            _ => Err(WireError::NonLiteralCollection),
+        },
+        Proc::CastMap(map) => match map.as_ref() {
+            Map::MapLit(entries) => {
+                let mut pairs = entries
+                    .iter()
+                    .map(|(key, value)| Ok((proc_to_par(key)?, proc_to_par(value)?)))
+                    .collect::<Result<Vec<_>, WireError>>()?;
+                sort_map_entries(&mut pairs);
+                Ok(Par {
+                    exprs: vec![Expr {
+                        expr_instance: Some(ExprInstance::EMapBody(EMap {
+                            kvs: pairs
+                                .into_iter()
+                                .map(|(key, value)| KeyValuePair {
+                                    key: Some(key),
+                                    value: Some(value),
+                                })
+                                .collect(),
+                        })),
+                    }],
+                })
+            },
+            _ => Err(WireError::NonLiteralCollection),
+        },
+        Proc::CastBag(bag) => match bag.as_ref() {
+            Bag::BagLit(elements) => {
+                let normalized = normalize_bag_elements(elements);
+                let mut ps = Vec::new();
+                for (elem, count) in normalized.iter() {
+                    let encoded = proc_to_par(elem)?;
+                    for _ in 0..count {
+                        ps.push(encoded.clone());
+                    }
+                }
+                Ok(Par {
+                    exprs: vec![Expr {
+                        expr_instance: Some(ExprInstance::EListBody(EList { ps })),
+                    }],
+                })
+            },
+            _ => Err(WireError::NonLiteralCollection),
+        },
+        _ => Err(WireError::UnsupportedProc),
+    }
+}
+
+pub(crate) fn collection_to_bytes(proc: &Proc) -> Result<Vec<u8>, WireError> {
+    let par = proc_to_par(proc)?;
+    Ok(par.encode_to_vec())
+}
+
+pub(crate) fn collection_to_byte_array_proc(proc: &Proc) -> Result<Proc, WireError> {
+    let bytes = collection_to_bytes(proc)?;
+    Ok(Proc::CastBytes(Box::new(super::Bytes::StringLit(hex::encode(bytes)))))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn list_123_matches_f1r3fly_reference() {
+        let proc = Proc::CastList(Box::new(List::ListLit(vec![
+            Proc::CastInt(Box::new(Int::NumLit(1))),
+            Proc::CastInt(Box::new(Int::NumLit(2))),
+            Proc::CastInt(Box::new(Int::NumLit(3))),
+        ])));
+        let bytes = collection_to_bytes(&proc).expect("encode list");
+        assert_eq!(hex::encode(bytes), "2a15a201120a042a0210020a042a0210040a042a021006");
+    }
+
+    #[test]
+    fn set_123_matches_f1r3fly_reference() {
+        let proc = Proc::CastSet(Box::new(Set::SetLit({
+            let mut set = HashSetLit::new();
+            set.insert(Proc::CastInt(Box::new(Int::NumLit(1))));
+            set.insert(Proc::CastInt(Box::new(Int::NumLit(2))));
+            set.insert(Proc::CastInt(Box::new(Int::NumLit(3))));
+            set
+        })));
+        let bytes = collection_to_bytes(&proc).expect("encode set");
+        assert_eq!(hex::encode(bytes), "2a15b201120a042a0210020a042a0210040a042a021006");
+    }
+
+    #[test]
+    fn map_12_matches_f1r3fly_reference() {
+        let mut map = HashMapLit::new();
+        map.insert(
+            Proc::CastInt(Box::new(Int::NumLit(1))),
+            Proc::CastInt(Box::new(Int::NumLit(10))),
+        );
+        map.insert(
+            Proc::CastInt(Box::new(Int::NumLit(2))),
+            Proc::CastInt(Box::new(Int::NumLit(20))),
+        );
+        let proc = Proc::CastMap(Box::new(Map::MapLit(map)));
+        let bytes = collection_to_bytes(&proc).expect("encode map");
+        assert_eq!(
+            hex::encode(bytes),
+            "2a1fba011c0a0c0a042a02100212042a0210140a0c0a042a02100412042a021028"
+        );
+    }
+
+    #[test]
+    fn nested_list_matches_reference() {
+        let proc = Proc::CastList(Box::new(List::ListLit(vec![
+            Proc::CastList(Box::new(List::ListLit(vec![
+                Proc::CastInt(Box::new(Int::NumLit(1))),
+                Proc::CastInt(Box::new(Int::NumLit(2))),
+            ]))),
+            Proc::CastList(Box::new(List::ListLit(vec![Proc::CastInt(Box::new(Int::NumLit(3)))]))),
+        ])));
+        let bytes = collection_to_bytes(&proc).expect("encode nested list");
+        assert_eq!(
+            hex::encode(bytes),
+            "2a23a201200a112a0fa2010c0a042a0210020a042a0210040a0b2a09a201060a042a021006"
+        );
+    }
+
+    #[test]
+    fn bag_multiset_matches_reference() {
+        let mut bag = HashBag::new();
+        bag.insert(Proc::CastInt(Box::new(Int::NumLit(1))));
+        bag.insert(Proc::CastInt(Box::new(Int::NumLit(2))));
+        bag.insert(Proc::CastInt(Box::new(Int::NumLit(2))));
+        let proc = Proc::CastBag(Box::new(Bag::BagLit(bag)));
+        let bytes = collection_to_bytes(&proc).expect("encode bag");
+        assert_eq!(hex::encode(bytes), "2a15a201120a042a0210040a042a0210040a042a021002");
+    }
+}

--- a/languages/tests/rhocalc_tests.rs
+++ b/languages/tests/rhocalc_tests.rs
@@ -1740,6 +1740,63 @@ mod native_ops {
         }
     }
 
+    mod collection_wire {
+        use super::*;
+
+        #[test]
+        fn list_to_byte_array_folds_to_hex() {
+            assert_reduces_to(
+                "[1, 2, 3].toByteArray()",
+                r#""2a15a201120a042a0210020a042a0210040a042a021006""#,
+            );
+        }
+
+        #[test]
+        fn set_to_byte_array_is_order_independent() {
+            assert_reduces_to(
+                "Set(1, 2, 3).toByteArray()",
+                r#""2a15b201120a042a0210020a042a0210040a042a021006""#,
+            );
+            assert_reduces_to(
+                "Set(3, 2, 1).toByteArray()",
+                r#""2a15b201120a042a0210020a042a0210040a042a021006""#,
+            );
+        }
+
+        #[test]
+        fn map_to_byte_array_is_order_independent() {
+            assert_reduces_to(
+                "{1: 10, 2: 20}.toByteArray()",
+                r#""2a1fba011c0a0c0a042a02100212042a0210140a0c0a042a02100412042a021028""#,
+            );
+            assert_reduces_to(
+                "{2: 20, 1: 10}.toByteArray()",
+                r#""2a1fba011c0a0c0a042a02100212042a0210140a0c0a042a02100412042a021028""#,
+            );
+        }
+
+        #[test]
+        fn nested_list_to_byte_array() {
+            assert_reduces_to(
+                "[[1, 2], [3]].toByteArray()",
+                r#""2a23a201200a112a0fa2010c0a042a0210020a042a0210040a0b2a09a201060a042a021006""#,
+            );
+        }
+
+        #[test]
+        fn bag_to_byte_array_expands_multiset() {
+            assert_reduces_to(
+                "#{1 | 2 | 2}#.toByteArray()",
+                r#""2a15a201120a042a0210040a042a0210040a042a021002""#,
+            );
+        }
+
+        #[test]
+        fn unsupported_receiver_errors() {
+            assert_never_reaches("[1, 2].length().toByteArray()", r#""0""#);
+        }
+    }
+
     mod type_conversion {
         use super::*;
 


### PR DESCRIPTION
Fold-time `.toByteArray()` on Rhocalc collection values injected into `Proc`, returning a `CastBytes` payload whose bytes match f1r3node `Par` protobuf encoding for the corresponding Rholang collection kind.